### PR TITLE
Fix warnings when building on Linux

### DIFF
--- a/async.c
+++ b/async.c
@@ -30,6 +30,7 @@
  */
 
 #include <string.h>
+#include <strings.h>
 #include <assert.h>
 #include <ctype.h>
 #include "async.h"


### PR DESCRIPTION
This commit simply adds an include for strings.h where strcasecmp and strncasecmp are defined.
