### PR TITLE
make install should install dict.h system-wide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ dep:
 
 install: ${DYLIBNAME} ${STLIBNAME}
 	mkdir -p $(INSTALL_INC) $(INSTALL_LIB)
-	$(INSTALL) hiredis.h async.h adapters $(INSTALL_INC)
+	$(INSTALL) hiredis.h async.h adapters dict.h $(INSTALL_INC)
 	$(INSTALL) ${DYLIBNAME} ${STLIBNAME} $(INSTALL_LIB)
 
 32bit:


### PR DESCRIPTION
async.h includes dict.h, so dict.h needs to be installed system-wide too.
This fixes compilation of example-libev.c when it is modified to use system-wide installed include files.
