### PR TITLE
Fix a mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ a single call to `read(2)`):
     redisAppendCommand(context,"SET foo bar");
     redisAppendCommand(context,"GET foo");
     redisGetReply(context,&reply); // reply for SET
-    freeReplyObject(reply);
     redisGetReply(context,&reply); // reply for GET
     freeReplyObject(reply);
 


### PR DESCRIPTION
The example of how to use the synchronous API had an extra call to freeReplyObject
