### PR TITLE
Fix the case where an error reply is received before any callbacks are registered

### DIFF
--- a/async.c
+++ b/async.c
@@ -362,12 +362,12 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
          * get a reply before pub/sub messages arrive. */
         if (__redisShiftCallback(&ac->replies,&cb) != REDIS_OK) {
             // error reply before any callbacks were setup
-            if ( ((redisReply*)reply)->type == REDIS_REPLY_ERROR ) {                                                                   
-                c->err = REDIS_ERR_OTHER;                                                                                              
-                err_len = strlen(((redisReply*)reply)->str);                                                                           
-                err_len = err_len < (sizeof(c->errstr)-1) ? err_len : (sizeof(c->errstr)-1);                                           
-                memcpy(c->errstr, ((redisReply*)reply)->str, err_len);                                                                 
-                c->errstr[err_len] = '\0';                                                                                             
+            if ( !(c->flags & REDIS_SUBSCRIBED) && ((redisReply*)reply)->type == REDIS_REPLY_ERROR ) {
+                c->err = REDIS_ERR_OTHER;
+                err_len = strlen(((redisReply*)reply)->str);
+                err_len = err_len < (sizeof(c->errstr)-1) ? err_len : (sizeof(c->errstr)-1);
+                memcpy(c->errstr, ((redisReply*)reply)->str, err_len);
+                c->errstr[err_len] = '\0';
                 __redisAsyncDisconnect(ac);
                 return;
             }


### PR DESCRIPTION
In an async context, if an error reply is received from the server before any callbacks have been registered, the callback processor (redisProcessCallbacks) assumes it's a subscribed context. This instance (error before callback registered) results in a failed assertion. This can be replicated by modifying the example-libevent.c main function as specified here: https://gist.github.com/988962

You'll see something like:

```
connectCallback: connected...
connectCallback: connected...
Assertion failed: (c->flags & REDIS_SUBSCRIBED), function redisProcessCallbacks, file async.c, line 377.
[1]    71052 abort      ./hiredis-example-libevent
```

The diff detects the condition where an error was received and handles it appropriately.
