### PR TITLE
Include stdlib.h in async.c for free(3), realloc(3) and strtol(3) support

### DIFF
--- a/async.c
+++ b/async.c
@@ -30,6 +30,7 @@
  */
 
 #include "fmacros.h"
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 #include <assert.h>


### PR DESCRIPTION
Another minor fix to quite some of clang's errors :)
