### PR TITLE
Fixing C++ support using g++ on Linux

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -1267,7 +1267,11 @@ void *redisvCommand(redisContext *c, const char *format, va_list ap) {
     return __redisBlockForReply(c);
 }
 
+#ifdef __cplusplus
+redisReply *redisCommand(redisContext *c, const char *format, ...) {
+#else
 void *redisCommand(redisContext *c, const char *format, ...) {
+#endif
     va_list ap;
     void *reply = NULL;
     va_start(ap,format);

--- a/hiredis.h
+++ b/hiredis.h
@@ -194,8 +194,15 @@ int redisAppendCommandArgv(redisContext *c, int argc, const char **argv, const s
  * return the reply. In a non-blocking context, it is identical to calling
  * only redisAppendCommand and will always return NULL. */
 void *redisvCommand(redisContext *c, const char *format, va_list ap);
-void *redisCommand(redisContext *c, const char *format, ...);
 void *redisCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen);
+
+#ifdef __cplusplus
+redisReply *redisCommand(redisContext *c, const char *format, ...);
+#else
+void *redisCommand(redisContext *c, const char *format, ...);
+#endif
+
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I found this fix somewhere on the internet, so I don't claim support.  Using these additions my project (which uses hiredis) can compile using both g++ and gcc perfectly.
