### PR TITLE
Increase read depth by one, would allow ruby redis client to read from slowlog

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -446,10 +446,10 @@ static int processMultiBulkItem(redisReader *r) {
     long elements;
     int root = 0;
 
-    /* Set error for nested multi bulks with depth > 1 */
-    if (r->ridx == 2) {
+    /* Set error for nested multi bulks with depth > 2 */
+    if (r->ridx == 3) {
         __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
-            "No support for nested multi bulk replies with depth > 1");
+            "No support for nested multi bulk replies with depth > 2");
         return REDIS_ERR;
     }
 

--- a/hiredis.h
+++ b/hiredis.h
@@ -123,7 +123,7 @@ typedef struct redisReader {
     size_t pos; /* Buffer cursor */
     size_t len; /* Buffer length */
 
-    redisReadTask rstack[3];
+    redisReadTask rstack[4];
     int ridx; /* Index of current read task */
     void *reply; /* Temporary reply pointer */
 

--- a/test.c
+++ b/test.c
@@ -225,8 +225,9 @@ static void test_reply_reader(void) {
               strcasecmp(reader->errstr,"Protocol error, got \"@\" as reply type byte") == 0);
     redisReaderFree(reader);
 
-    test("Set error on nested multi bulks with depth > 1: ");
+    test("Set error on nested multi bulks with depth > 2: ");
     reader = redisReaderCreate();
+    redisReaderFeed(reader,(char*)"*1\r\n",4);
     redisReaderFeed(reader,(char*)"*1\r\n",4);
     redisReaderFeed(reader,(char*)"*1\r\n",4);
     redisReaderFeed(reader,(char*)"*1\r\n",4);


### PR DESCRIPTION
Increasing this depth by 1 would allow ruby to do this:

```
class Redis
  def slowlog(subcommand, length=nil)
    synchronize do
      args = [:slowlog, subcommand]
      args << length if length
      @client.call args
    end
  end
end
```

and produce results like this:

```
>> Resque.redis.slowlog "get", 1
=> [[2073, 1322833007, 9, ["LPOP", "resque:render_queue"]]]
>> Resque.redis.slowlog "get", 2
=> [[2078, 1322833012, 8, ["LPOP", "resque:render_queue"]], [2077, 1322833011, 11, ["LPOP", "resque:render_queue"]]]
```

I implemented this locally and it works great.  I'd really like to get SLOWLOG into redis-rb ASAP.

Are there any disadvantages to this? If you don't want to patch hiredis this way, could it be possible to vendor a special version in the hiredis-rb package for this purpose?

Thanks!
