### PR TITLE
SIGPIPE fault in iOS

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -36,7 +36,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <ctype.h>
-
+#include <sys/socket.h>
 #include "hiredis.h"
 #include "net.h"
 #include "sds.h"
@@ -1106,6 +1106,9 @@ int redisBufferRead(redisContext *c) {
 int redisBufferWrite(redisContext *c, int *done) {
     int nwritten;
 
+    int set = 1;
+    setsockopt(c->fd, SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(int));
+    
     /* Return early when the context has seen an error. */
     if (c->err)
         return REDIS_ERR;


### PR DESCRIPTION
Easiest solution seems to set options for the socket to ignore SIGPIPE on write. Is there any other solution/patch I could use?
