### PR TITLE
Fix issue with redisContextWaitReady() with reading fd numbers > FD_SETS...

### DIFF
--- a/net.c
+++ b/net.c
@@ -136,7 +136,7 @@ static int redisContextWaitReady(redisContext *c, int fd, const struct timeval *
         FD_ZERO(&wfd);
         FD_SET(fd, &wfd);
 
-        if (select(FD_SETSIZE, NULL, &wfd, NULL, toptr) == -1) {
+        if (select(fd+1, NULL, &wfd, NULL, toptr) == -1) {
             __redisSetErrorFromErrno(c,REDIS_ERR_IO,"select(2)");
             close(fd);
             return REDIS_ERR;


### PR DESCRIPTION
redisContextWaitReady() incorrectly uses the first argument in select(). In this
case, if a file descriptor is > 1024 (not the number of fd's in fd_set), the
operation is called on an empty set which will never return.

Instead we should call select(fd+1, ....);
