### PR TITLE
Mark the timeout argument as const in connect related functions

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -1019,7 +1019,7 @@ redisContext *redisConnect(const char *ip, int port) {
     return c;
 }
 
-redisContext *redisConnectWithTimeout(const char *ip, int port, struct timeval tv) {
+redisContext *redisConnectWithTimeout(const char *ip, int port, const struct timeval tv) {
     redisContext *c = redisContextInit();
     c->flags |= REDIS_BLOCK;
     redisContextConnectTcp(c,ip,port,&tv);
@@ -1040,7 +1040,7 @@ redisContext *redisConnectUnix(const char *path) {
     return c;
 }
 
-redisContext *redisConnectUnixWithTimeout(const char *path, struct timeval tv) {
+redisContext *redisConnectUnixWithTimeout(const char *path, const struct timeval tv) {
     redisContext *c = redisContextInit();
     c->flags |= REDIS_BLOCK;
     redisContextConnectUnix(c,path,&tv);
@@ -1055,7 +1055,7 @@ redisContext *redisConnectUnixNonBlock(const char *path) {
 }
 
 /* Set read/write timeout on a blocking socket. */
-int redisSetTimeout(redisContext *c, struct timeval tv) {
+int redisSetTimeout(redisContext *c, const struct timeval tv) {
     if (c->flags & REDIS_BLOCK)
         return redisContextSetTimeout(c,tv);
     return REDIS_ERR;

--- a/hiredis.h
+++ b/hiredis.h
@@ -165,12 +165,12 @@ typedef struct redisContext {
 } redisContext;
 
 redisContext *redisConnect(const char *ip, int port);
-redisContext *redisConnectWithTimeout(const char *ip, int port, struct timeval tv);
+redisContext *redisConnectWithTimeout(const char *ip, int port, const struct timeval tv);
 redisContext *redisConnectNonBlock(const char *ip, int port);
 redisContext *redisConnectUnix(const char *path);
-redisContext *redisConnectUnixWithTimeout(const char *path, struct timeval tv);
+redisContext *redisConnectUnixWithTimeout(const char *path, const struct timeval tv);
 redisContext *redisConnectUnixNonBlock(const char *path);
-int redisSetTimeout(redisContext *c, struct timeval tv);
+int redisSetTimeout(redisContext *c, const struct timeval tv);
 void redisFree(redisContext *c);
 int redisBufferRead(redisContext *c);
 int redisBufferWrite(redisContext *c, int *done);

--- a/net.c
+++ b/net.c
@@ -192,7 +192,7 @@ int redisCheckSocketError(redisContext *c, int fd) {
     return REDIS_OK;
 }
 
-int redisContextSetTimeout(redisContext *c, struct timeval tv) {
+int redisContextSetTimeout(redisContext *c, const struct timeval tv) {
     if (setsockopt(c->fd,SOL_SOCKET,SO_RCVTIMEO,&tv,sizeof(tv)) == -1) {
         __redisSetErrorFromErrno(c,REDIS_ERR_IO,"setsockopt(SO_RCVTIMEO)");
         return REDIS_ERR;
@@ -204,7 +204,7 @@ int redisContextSetTimeout(redisContext *c, struct timeval tv) {
     return REDIS_OK;
 }
 
-int redisContextConnectTcp(redisContext *c, const char *addr, int port, struct timeval *timeout) {
+int redisContextConnectTcp(redisContext *c, const char *addr, int port, const struct timeval *timeout) {
     int s, rv;
     char _port[6];  /* strlen("65535"); */
     struct addrinfo hints, *servinfo, *p;
@@ -260,7 +260,7 @@ end:
     return rv;  // Need to return REDIS_OK if alright
 }
 
-int redisContextConnectUnix(redisContext *c, const char *path, struct timeval *timeout) {
+int redisContextConnectUnix(redisContext *c, const char *path, const struct timeval *timeout) {
     int s;
     int blocking = (c->flags & REDIS_BLOCK);
     struct sockaddr_un sa;

--- a/net.h
+++ b/net.h
@@ -40,8 +40,8 @@
 #endif
 
 int redisCheckSocketError(redisContext *c, int fd);
-int redisContextSetTimeout(redisContext *c, struct timeval tv);
-int redisContextConnectTcp(redisContext *c, const char *addr, int port, struct timeval *timeout);
-int redisContextConnectUnix(redisContext *c, const char *path, struct timeval *timeout);
+int redisContextSetTimeout(redisContext *c, const struct timeval tv);
+int redisContextConnectTcp(redisContext *c, const char *addr, int port, const struct timeval *timeout);
+int redisContextConnectUnix(redisContext *c, const char *path, const struct timeval *timeout);
 
 #endif


### PR DESCRIPTION
The struct timeval argument in redisConnectWithTimeout(),
redisConnectUnixWithTimeout(), redisSetTimeout(),
redisContextSetTimeout(), redisContextConnectTcp()
and redisContextConnectUnix() is never modified and can
therefore be marked as const.

Signed-off-by: Noah Williamsson noah.williamsson@gmail.com
