### PR TITLE
MONITOR causes assertion failure, async.c, line 398.

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -76,6 +76,9 @@
 /* Flag that is set when the async context has one or more subscriptions. */
 #define REDIS_SUBSCRIBED 0x20
 
+/* Flag that is set when monitor mode is active */
+#define REDIS_MONITORING 0x40
+
 #define REDIS_REPLY_STRING 1
 #define REDIS_REPLY_ARRAY 2
 #define REDIS_REPLY_INTEGER 3


### PR DESCRIPTION
I've built a client using an asynchronous adapter. After receiving a few responses following "monitor":
Assertion failed: (c->flags & REDIS_SUBSCRIBED), function redisProcessCallbacks, file async.c, line 398.

It looks like this has gone unnoticed because most of the implementations have their own async client implementation instead of using one that's provided. That's too bad because I think the subscription callbacks are very useful! Anyways...

Currently async.c is such that, for every command issued, there must be only one reply; except subscriptions, in which case a check is performed so that appropriate subscription callback can be repetitively called. However, the case of replies because of Monitor isn't considered, so the crash occurs.

You can reproduce this by adding to any of the examples:
redisAsyncCommand(c, getCallback, NULL, "MONITOR");

Then run a few commands on another connection and you should get crash.
