### PR TITLE
Fix segfaults in redisConnect*

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -1014,6 +1014,8 @@ void redisFree(redisContext *c) {
  * When no set of reply functions is given, the default set will be used. */
 redisContext *redisConnect(const char *ip, int port) {
     redisContext *c = redisContextInit();
+    if (c == NULL)
+       return NULL;
     c->flags |= REDIS_BLOCK;
     redisContextConnectTcp(c,ip,port,NULL);
     return c;
@@ -1021,6 +1023,8 @@ redisContext *redisConnect(const char *ip, int port) {
 
 redisContext *redisConnectWithTimeout(const char *ip, int port, struct timeval tv) {
     redisContext *c = redisContextInit();
+    if (c == NULL)
+       return NULL;
     c->flags |= REDIS_BLOCK;
     redisContextConnectTcp(c,ip,port,&tv);
     return c;
@@ -1028,6 +1032,8 @@ redisContext *redisConnectWithTimeout(const char *ip, int port, struct timeval t
 
 redisContext *redisConnectNonBlock(const char *ip, int port) {
     redisContext *c = redisContextInit();
+    if (c == NULL)
+       return NULL;
     c->flags &= ~REDIS_BLOCK;
     redisContextConnectTcp(c,ip,port,NULL);
     return c;
@@ -1035,6 +1041,8 @@ redisContext *redisConnectNonBlock(const char *ip, int port) {
 
 redisContext *redisConnectUnix(const char *path) {
     redisContext *c = redisContextInit();
+    if (c == NULL)
+       return NULL;
     c->flags |= REDIS_BLOCK;
     redisContextConnectUnix(c,path,NULL);
     return c;
@@ -1042,6 +1050,8 @@ redisContext *redisConnectUnix(const char *path) {
 
 redisContext *redisConnectUnixWithTimeout(const char *path, struct timeval tv) {
     redisContext *c = redisContextInit();
+    if (c == NULL)
+       return NULL;
     c->flags |= REDIS_BLOCK;
     redisContextConnectUnix(c,path,&tv);
     return c;
@@ -1049,6 +1059,8 @@ redisContext *redisConnectUnixWithTimeout(const char *path, struct timeval tv) {
 
 redisContext *redisConnectUnixNonBlock(const char *path) {
     redisContext *c = redisContextInit();
+    if (c == NULL)
+       return NULL;
     c->flags &= ~REDIS_BLOCK;
     redisContextConnectUnix(c,path,NULL);
     return c;


### PR DESCRIPTION
redisConnect\* functions crash when redisContextInit() returns NULL.
This simple patch fixes this.
