### PR TITLE
make redisConnectWithTimeout connect to 127.0.0.1 instead of 127.0.0.2 

### DIFF
--- a/example.c
+++ b/example.c
@@ -10,7 +10,7 @@ int main(void) {
     redisReply *reply;
 
     struct timeval timeout = { 1, 500000 }; // 1.5 seconds
-    c = redisConnectWithTimeout((char*)"127.0.0.2", 6379, timeout);
+    c = redisConnectWithTimeout((char*)"127.0.0.1", 6379, timeout);
     if (c->err) {
         printf("Connection error: %s\n", c->errstr);
         exit(1);


### PR DESCRIPTION
Hello,

Here's a small fix, to ease the use of ./hiredis-example

Thanks!

Charles
