### PR TITLE
Prevent hiredis from crashing on memory allocation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,27 +88,28 @@ The standard replies that `redisCommand` are of the type `redisReply`. The
 was received:
 
 * **`REDIS_REPLY_STATUS`**:
-    * The command replied with a status reply. The status string can be accessed using `reply->str`.
-      The length of this string can be accessed using `reply->len`.
+    * The command replied with a status reply. The status string can be accessed using `reply->reply_status.str`.
+      The length of this string can be accessed using `reply->reply_status.len`.
 
 * **`REDIS_REPLY_ERROR`**:
-    *  The command replied with an error. The error string can be accessed identical to `REDIS_REPLY_STATUS`.
+    *  The command replied with an error. The error string can be accessed using `reply->reply_error.str`.
+      The length of this string can be accessed using `reply->reply_error.len`.
 
 * **`REDIS_REPLY_INTEGER`**:
     * The command replied with an integer. The integer value can be accessed using the
-      `reply->integer` field of type `long long`.
+      `reply->reply_integer.integer` field of type `long long`.
 
 * **`REDIS_REPLY_NIL`**:
     * The command replied with a **nil** object. There is no data to access.
 
 * **`REDIS_REPLY_STRING`**:
-    * A bulk (string) reply. The value of the reply can be accessed using `reply->str`.
-      The length of this string can be accessed using `reply->len`.
+    * A bulk (string) reply. The value of the reply can be accessed using `reply->reply_string.str`.
+      The length of this string can be accessed using `reply->reply_string.len`.
 
 * **`REDIS_REPLY_ARRAY`**:
     * A multi bulk reply. The number of elements in the multi bulk reply is stored in
-      `reply->elements`. Every element in the multi bulk reply is a `redisReply` object as well
-      and can be accessed via `reply->element[..index..]`.
+      `reply->reply_array.elements`. Every element in the multi bulk reply is a `redisReply`
+      object as well and can be accessed via `reply->reply_array.element[..index..]`.
       Redis may reply with nested arrays but this is fully supported.
 
 Replies should be freed using the `freeReplyObject()` function.
@@ -341,11 +342,11 @@ wrong (either a protocol error, or an out of memory error).
 
 The function `redisReaderGetReply` creates `redisReply` and makes the function
 argument `reply` point to the created `redisReply` variable. For instance, if
-the response of type `REDIS_REPLY_STATUS` then the `str` field of `redisReply`
-will hold the status as a vanilla C string. However, the functions that are
-responsible for creating instances of the `redisReply` can be customized by
-setting the `fn` field on the `redisReader` struct. This should be done
-immediately after creating the `redisReader`.
+the response of type `REDIS_REPLY_STATUS` then the `reply_string.str` field
+of `redisReply` will hold the status as a vanilla C string. However, the
+functions that are responsible for creating instances of the `redisReply` can
+be customized by setting the `fn` field on the `redisReader` struct. This should
+be done immediately after creating the `redisReader`.
 
 For example, [hiredis-rb](https://github.com/pietern/hiredis-rb/blob/master/ext/hiredis_ext/reader.c)
 uses customized reply object functions to create Ruby objects.

--- a/example-ae.c
+++ b/example-ae.c
@@ -11,8 +11,11 @@ static aeEventLoop *loop;
 
 void getCallback(redisAsyncContext *c, void *r, void *privdata) {
     redisReply *reply = r;
-    if (reply == NULL) return;
-    printf("argv[%s]: %s\n", (char*)privdata, reply->str);
+
+    if (reply == NULL || reply->type != REDIS_REPLY_STRING)
+        return;
+
+    printf("argv[%s]: %s\n", (char*)privdata, reply->string.str);
 
     /* Disconnect after receiving the reply to GET */
     redisAsyncDisconnect(c);

--- a/example-libev.c
+++ b/example-libev.c
@@ -8,8 +8,11 @@
 
 void getCallback(redisAsyncContext *c, void *r, void *privdata) {
     redisReply *reply = r;
-    if (reply == NULL) return;
-    printf("argv[%s]: %s\n", (char*)privdata, reply->str);
+
+    if (reply == NULL || reply->type != REDIS_REPLY_STRING)
+        return;
+
+    printf("argv[%s]: %s\n", (char*)privdata, reply->string.str);
 
     /* Disconnect after receiving the reply to GET */
     redisAsyncDisconnect(c);

--- a/example-libevent.c
+++ b/example-libevent.c
@@ -8,8 +8,11 @@
 
 void getCallback(redisAsyncContext *c, void *r, void *privdata) {
     redisReply *reply = r;
-    if (reply == NULL) return;
-    printf("argv[%s]: %s\n", (char*)privdata, reply->str);
+
+    if (reply == NULL || reply->type != REDIS_REPLY_STRING)
+        return;
+
+    printf("argv[%s]: %s\n", (char*)privdata, reply->string.str);
 
     /* Disconnect after receiving the reply to GET */
     redisAsyncDisconnect(c);

--- a/example.c
+++ b/example.c
@@ -23,30 +23,30 @@ int main(void) {
 
     /* PING server */
     reply = redisCommand(c,"PING");
-    printf("PING: %s\n", reply->str);
+    printf("PING: %s\n", reply->reply_string.str);
     freeReplyObject(reply);
 
     /* Set a key */
     reply = redisCommand(c,"SET %s %s", "foo", "hello world");
-    printf("SET: %s\n", reply->str);
+    printf("SET: %s\n", reply->reply_string.str);
     freeReplyObject(reply);
 
     /* Set a key using binary safe API */
     reply = redisCommand(c,"SET %b %b", "bar", 3, "hello", 5);
-    printf("SET (binary API): %s\n", reply->str);
+    printf("SET (binary API): %s\n", reply->reply_string.str);
     freeReplyObject(reply);
 
     /* Try a GET and two INCR */
     reply = redisCommand(c,"GET foo");
-    printf("GET foo: %s\n", reply->str);
+    printf("GET foo: %s\n", reply->reply_string.str);
     freeReplyObject(reply);
 
     reply = redisCommand(c,"INCR counter");
-    printf("INCR counter: %lld\n", reply->integer);
+    printf("INCR counter: %lld\n", reply->reply_integer);
     freeReplyObject(reply);
     /* again ... */
     reply = redisCommand(c,"INCR counter");
-    printf("INCR counter: %lld\n", reply->integer);
+    printf("INCR counter: %lld\n", reply->reply_integer);
     freeReplyObject(reply);
 
     /* Create a list of numbers, from 0 to 9 */
@@ -63,8 +63,11 @@ int main(void) {
     /* Let's check what we have inside the list */
     reply = redisCommand(c,"LRANGE mylist 0 -1");
     if (reply->type == REDIS_REPLY_ARRAY) {
-        for (j = 0; j < reply->elements; j++) {
-            printf("%u) %s\n", j, reply->element[j]->str);
+        for (j = 0; j < reply->reply_array.elements; j++) {
+            redisReply *elm;
+
+            elm = reply->reply_array.element[j];
+            printf("%u) %s\n", j, elm->reply_string.str);
         }
     }
     freeReplyObject(reply);

--- a/hiredis.c
+++ b/hiredis.c
@@ -77,18 +77,27 @@ void freeReplyObject(void *reply) {
     case REDIS_REPLY_INTEGER:
         break; /* Nothing to free */
     case REDIS_REPLY_ARRAY:
-        if (r->element != NULL) {
-            for (j = 0; j < r->elements; j++)
-                if (r->element[j] != NULL)
-                    freeReplyObject(r->element[j]);
-            free(r->element);
+        if (r->reply_array.element != NULL) {
+            for (j = 0; j < r->reply_array.elements; j++)
+                if (r->reply_array.element[j] != NULL)
+                    freeReplyObject(r->reply_array.element[j]);
+            free(r->reply_array.element);
         }
         break;
     case REDIS_REPLY_ERROR:
+        if (r->reply_error.str != NULL)
+            free(r->reply_error.str);
+        break;
     case REDIS_REPLY_STATUS:
+        if (r->reply_status.str != NULL)
+            free(r->reply_status.str);
+        break;
     case REDIS_REPLY_STRING:
-        if (r->str != NULL)
-            free(r->str);
+        if (r->reply_string.str != NULL)
+            free(r->reply_string.str);
+        break;
+    default:
+        /* Nothing to do */
         break;
     }
     free(r);
@@ -108,20 +117,32 @@ static void *createStringObject(const redisReadTask *task, char *str, size_t len
         return NULL;
     }
 
-    assert(task->type == REDIS_REPLY_ERROR  ||
-           task->type == REDIS_REPLY_STATUS ||
-           task->type == REDIS_REPLY_STRING);
-
     /* Copy string value */
     memcpy(buf,str,len);
     buf[len] = '\0';
-    r->str = buf;
-    r->len = len;
+
+    switch(task->type) {
+    case REDIS_REPLY_ERROR:
+        r->reply_error.str = buf;
+        r->reply_error.len = len;
+        break;
+    case REDIS_REPLY_STATUS:
+        r->reply_status.str = buf;
+        r->reply_status.len = len;
+        break;
+    case REDIS_REPLY_STRING:
+        r->reply_string.str = buf;
+        r->reply_string.len = len;
+        break;
+    default:
+        freeReplyObject(r);
+        return NULL;
+    }
 
     if (task->parent) {
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY);
-        parent->element[task->idx] = r;
+        parent->reply_array.element[task->idx] = r;
     }
     return r;
 }
@@ -134,19 +155,19 @@ static void *createArrayObject(const redisReadTask *task, int elements) {
         return NULL;
 
     if (elements > 0) {
-        r->element = calloc(elements,sizeof(redisReply*));
-        if (r->element == NULL) {
+        r->reply_array.element = calloc(elements,sizeof(redisReply*));
+        if (r->reply_array.element == NULL) {
             freeReplyObject(r);
             return NULL;
         }
     }
 
-    r->elements = elements;
+    r->reply_array.elements = elements;
 
     if (task->parent) {
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY);
-        parent->element[task->idx] = r;
+        parent->reply_array.element[task->idx] = r;
     }
     return r;
 }
@@ -158,12 +179,12 @@ static void *createIntegerObject(const redisReadTask *task, long long value) {
     if (r == NULL)
         return NULL;
 
-    r->integer = value;
+    r->reply_integer = value;
 
     if (task->parent) {
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY);
-        parent->element[task->idx] = r;
+        parent->reply_array.element[task->idx] = r;
     }
     return r;
 }
@@ -178,7 +199,7 @@ static void *createNilObject(const redisReadTask *task) {
     if (task->parent) {
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY);
-        parent->element[task->idx] = r;
+        parent->reply_array.element[task->idx] = r;
     }
     return r;
 }

--- a/hiredis.h
+++ b/hiredis.h
@@ -79,12 +79,14 @@
 /* Flag that is set when monitor mode is active */
 #define REDIS_MONITORING 0x40
 
-#define REDIS_REPLY_STRING 1
-#define REDIS_REPLY_ARRAY 2
-#define REDIS_REPLY_INTEGER 3
-#define REDIS_REPLY_NIL 4
-#define REDIS_REPLY_STATUS 5
-#define REDIS_REPLY_ERROR 6
+typedef enum {
+    REDIS_REPLY_NIL,
+    REDIS_REPLY_STRING,
+    REDIS_REPLY_ARRAY,
+    REDIS_REPLY_INTEGER,
+    REDIS_REPLY_STATUS,
+    REDIS_REPLY_ERROR
+} redis_type_t;
 
 #define REDIS_READER_MAX_BUF (1024*16)  /* Default max unused reader buffer. */
 
@@ -94,13 +96,30 @@ extern "C" {
 
 /* This is the reply object returned by redisCommand() */
 typedef struct redisReply {
-    int type; /* REDIS_REPLY_* */
-    long long integer; /* The integer when type is REDIS_REPLY_INTEGER */
-    int len; /* Length of string */
-    char *str; /* Used for both REDIS_REPLY_ERROR and REDIS_REPLY_STRING */
-    size_t elements; /* number of elements, for REDIS_REPLY_ARRAY */
-    struct redisReply **element; /* elements vector for REDIS_REPLY_ARRAY */
+    redis_type_t type;
+
+    union {
+        /* REDIS_REPLY_INTEGER */
+        long long __integer;
+
+        struct {
+            /* REDIS_REPLY_STRING, REDIS_REPLY_STATUS, REDIS_REPLY_ERROR */
+            size_t len; /* Length of string */
+            char *str;
+        } __string;
+
+        struct {
+            /* REDIS_REPLY_ARRAY */
+            size_t elements;             /* number of elements, for REDIS_REPLY_ARRAY */
+            struct redisReply **element; /* elements vector for REDIS_REPLY_ARRAY */
+        } __array;
+    } __reply_un;
 } redisReply;
+#define reply_integer  __reply_un.__integer
+#define reply_string   __reply_un.__string
+#define reply_status   __reply_un.__string
+#define reply_error    __reply_un.__string
+#define reply_array    __reply_un.__array
 
 typedef struct redisReadTask {
     int type;

--- a/test.c
+++ b/test.c
@@ -51,7 +51,7 @@ static redisContext *select_database(redisContext *c) {
     /* Make sure the DB is emtpy */
     reply = redisCommand(c,"DBSIZE");
     assert(reply != NULL);
-    if (reply->type == REDIS_REPLY_INTEGER && reply->integer == 0) {
+    if (reply->type == REDIS_REPLY_INTEGER && reply->reply_integer == 0) {
         /* Awesome, DB 9 is empty and we can continue. */
         freeReplyObject(reply);
     } else {
@@ -277,7 +277,7 @@ static void test_reply_reader(void) {
     ret = redisReaderGetReply(reader,&reply);
     test_cond(ret == REDIS_OK &&
         ((redisReply*)reply)->type == REDIS_REPLY_ARRAY &&
-        ((redisReply*)reply)->elements == 0);
+        ((redisReply*)reply)->reply_array.elements == 0);
     freeReplyObject(reply);
     redisReaderFree(reader);
 }
@@ -313,13 +313,13 @@ static void test_blocking_connection(struct config config) {
     test("Is able to deliver commands: ");
     reply = redisCommand(c,"PING");
     test_cond(reply->type == REDIS_REPLY_STATUS &&
-        strcasecmp(reply->str,"pong") == 0)
+        strcasecmp(reply->reply_string.str,"pong") == 0)
     freeReplyObject(reply);
 
     test("Is a able to send commands verbatim: ");
     reply = redisCommand(c,"SET foo bar");
     test_cond (reply->type == REDIS_REPLY_STATUS &&
-        strcasecmp(reply->str,"ok") == 0)
+        strcasecmp(reply->reply_string.str,"ok") == 0)
     freeReplyObject(reply);
 
     test("%%s String interpolation works: ");
@@ -327,7 +327,7 @@ static void test_blocking_connection(struct config config) {
     freeReplyObject(reply);
     reply = redisCommand(c,"GET foo");
     test_cond(reply->type == REDIS_REPLY_STRING &&
-        strcmp(reply->str,"hello world") == 0);
+        strcmp(reply->reply_string.str,"hello world") == 0);
     freeReplyObject(reply);
 
     test("%%b String interpolation works: ");
@@ -335,10 +335,10 @@ static void test_blocking_connection(struct config config) {
     freeReplyObject(reply);
     reply = redisCommand(c,"GET foo");
     test_cond(reply->type == REDIS_REPLY_STRING &&
-        memcmp(reply->str,"hello\x00world",11) == 0)
+        memcmp(reply->reply_string.str,"hello\x00world",11) == 0)
 
     test("Binary reply length is correct: ");
-    test_cond(reply->len == 11)
+    test_cond(reply->reply_string.len == 11)
     freeReplyObject(reply);
 
     test("Can parse nil replies: ");
@@ -349,7 +349,7 @@ static void test_blocking_connection(struct config config) {
     /* test 7 */
     test("Can parse integer replies: ");
     reply = redisCommand(c,"INCR mycounter");
-    test_cond(reply->type == REDIS_REPLY_INTEGER && reply->integer == 1)
+    test_cond(reply->type == REDIS_REPLY_INTEGER && reply->reply_integer == 1)
     freeReplyObject(reply);
 
     test("Can parse multi bulk replies: ");
@@ -357,9 +357,9 @@ static void test_blocking_connection(struct config config) {
     freeReplyObject(redisCommand(c,"LPUSH mylist bar"));
     reply = redisCommand(c,"LRANGE mylist 0 -1");
     test_cond(reply->type == REDIS_REPLY_ARRAY &&
-              reply->elements == 2 &&
-              !memcmp(reply->element[0]->str,"bar",3) &&
-              !memcmp(reply->element[1]->str,"foo",3))
+              reply->reply_array.elements == 2 &&
+              !memcmp(reply->reply_array.element[0]->reply_string.str,"bar",3) &&
+              !memcmp(reply->reply_array.element[1]->reply_string.str,"foo",3))
     freeReplyObject(reply);
 
     /* m/e with multi bulk reply *before* other reply.
@@ -370,13 +370,13 @@ static void test_blocking_connection(struct config config) {
     freeReplyObject(redisCommand(c,"PING"));
     reply = (redisCommand(c,"EXEC"));
     test_cond(reply->type == REDIS_REPLY_ARRAY &&
-              reply->elements == 2 &&
-              reply->element[0]->type == REDIS_REPLY_ARRAY &&
-              reply->element[0]->elements == 2 &&
-              !memcmp(reply->element[0]->element[0]->str,"bar",3) &&
-              !memcmp(reply->element[0]->element[1]->str,"foo",3) &&
-              reply->element[1]->type == REDIS_REPLY_STATUS &&
-              strcasecmp(reply->element[1]->str,"pong") == 0);
+              reply->reply_array.elements == 2 &&
+              reply->reply_array.element[0]->type == REDIS_REPLY_ARRAY &&
+              reply->reply_array.element[0]->reply_array.elements == 2 &&
+              !memcmp(reply->reply_array.element[0]->reply_array.element[0]->reply_string.str,"bar",3) &&
+              !memcmp(reply->reply_array.element[0]->reply_array.element[1]->reply_string.str,"foo",3) &&
+              reply->reply_array.element[1]->type == REDIS_REPLY_STATUS &&
+              strcasecmp(reply->reply_array.element[1]->reply_string.str,"pong") == 0);
     freeReplyObject(reply);
 
     disconnect(c);
@@ -396,7 +396,7 @@ static void test_blocking_io_errors(struct config config) {
         char *p, *eptr;
 
         reply = redisCommand(c,"INFO");
-        p = strstr(reply->str,field);
+        p = strstr(reply->reply_string.str,field);
         major = strtol(p+strlen(field),&eptr,10);
         p = eptr+1; /* char next to the first "." */
         minor = strtol(p,&eptr,10);
@@ -408,7 +408,7 @@ static void test_blocking_io_errors(struct config config) {
     if (major >= 2 && minor > 0) {
         /* > 2.0 returns OK on QUIT and read() should be issued once more
          * to know the descriptor is at EOF. */
-        test_cond(strcasecmp(reply->str,"OK") == 0 &&
+        test_cond(strcasecmp(reply->reply_string.str,"OK") == 0 &&
             redisGetReply(c,&_reply) == REDIS_ERR);
         freeReplyObject(reply);
     } else {
@@ -460,7 +460,7 @@ static void test_throughput(struct config config) {
     for (i = 0; i < num; i++) {
         replies[i] = redisCommand(c,"LRANGE mylist 0 499");
         assert(replies[i] != NULL && replies[i]->type == REDIS_REPLY_ARRAY);
-        assert(replies[i] != NULL && replies[i]->elements == 500);
+        assert(replies[i] != NULL && replies[i]->reply_array.elements == 500);
     }
     t2 = usec();
     for (i = 0; i < num; i++) freeReplyObject(replies[i]);
@@ -488,7 +488,7 @@ static void test_throughput(struct config config) {
     for (i = 0; i < num; i++) {
         assert(redisGetReply(c, (void*)&replies[i]) == REDIS_OK);
         assert(replies[i] != NULL && replies[i]->type == REDIS_REPLY_ARRAY);
-        assert(replies[i] != NULL && replies[i]->elements == 500);
+        assert(replies[i] != NULL && replies[i]->reply_array.elements == 500);
     }
     t2 = usec();
     for (i = 0; i < num; i++) freeReplyObject(replies[i]);
@@ -554,7 +554,7 @@ static void test_throughput(struct config config) {
 //     c = __connect_nonblock();
 //     redisCommand(c,"PING");
 //     test_cond(redisBufferWrite(c,NULL) == REDIS_ERR &&
-//               strncmp(c->error,"write:",6) == 0);
+//               strncmp(c->reply_error,"write:",6) == 0);
 //     redisFree(c);
 //
 //     test("redisBufferWrite against closed fd: ");
@@ -562,7 +562,7 @@ static void test_throughput(struct config config) {
 //     redisCommand(c,"PING");
 //     redisDisconnect(c);
 //     test_cond(redisBufferWrite(c,NULL) == REDIS_ERR &&
-//               strncmp(c->error,"write:",6) == 0);
+//               strncmp(c->reply_error,"write:",6) == 0);
 //     redisFree(c);
 //
 //     test("Process callbacks in the right sequence: ");


### PR DESCRIPTION
Updated redisConnect functions to make them check that the context is properly allocated (i.e.: non-NULL) before attempting to dereference it. These functions can therefore return NULL to the callers in such cases.

Updated documentation and examples accordingly.
