### PR TITLE
Fix tests for test_blocking_connection_errors();

### DIFF
--- a/test.c
+++ b/test.c
@@ -289,7 +289,9 @@ static void test_blocking_connection_errors(void) {
     c = redisConnect((char*)"idontexist.local", 6379);
     test_cond(c->err == REDIS_ERR_OTHER &&
         (strcmp(c->errstr,"Name or service not known") == 0 ||
-         strcmp(c->errstr,"Can't resolve: idontexist.local") == 0));
+         strcmp(c->errstr,"Can't resolve: idontexist.local") == 0) ||
+	 strcmp(c->errstr,"nodename nor servname provided, or not known") ||
+	 strcmp(c->errstr,"no address associated with name"));
     redisFree(c);
 
     test("Returns error when the port is not open: ");


### PR DESCRIPTION
A test function is comparing strings returned from gai_strerror() after an unsuccessful
call to getaddrinfo(), the problem is that the strings returned from gai_strerror() are implementation defined according to POSIX. 

I thought about adding REDIS_ERR_NONAME and set that based on the return value
from getaddrinfo (EAI_NONAME in this case) but as it happens OpenBSD fails to return
a proper error code (It returns -5, which I'm hunting down now) and I'm unsure how that would
play with things in the wild.
