### PR TITLE
Set error on invalid timval values for redisConnectWithTimeout (Fixes #154)

### DIFF
--- a/net.c
+++ b/net.c
@@ -136,6 +136,7 @@ static int redisContextWaitReady(redisContext *c, int fd, const struct timeval *
     /* Only use timeout when not NULL. */
     if (timeout != NULL) {
         if (timeout->tv_usec > 1000000 || timeout->tv_sec > __MAX_MSEC) {
+	     __redisSetErrorFromErrno(c, REDIS_ERR_IO, NULL);
             close(fd);
             return REDIS_ERR;
         }


### PR DESCRIPTION
This commit properly sets the error value inside of
redisContextWaitReady when an invalid sec or usec value is provided.
Tests for each case are provided to demonstrate that the issue is
properly fixed and to avoid regression.

Signed-off-by: Aaron Bedra aaron@aaronbedra.com
