### PR TITLE
KeepAlive.

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -1092,6 +1092,13 @@ int redisSetTimeout(redisContext *c, struct timeval tv) {
     return REDIS_ERR;
 }
 
+/* Enable connection KeepAlive. */
+int redisEnableKeepAlive(redisContext *c) {
+    if (redisKeepAlive(c, REDIS_KEEPALIVE_INTERVAL) != REDIS_OK)
+        return REDIS_ERR;
+    return REDIS_OK;
+}
+
 /* Use this function to handle a read event on the descriptor. It will try
  * and read some bytes from the socket and feed them to the reply parser.
  *

--- a/hiredis.h
+++ b/hiredis.h
@@ -179,6 +179,7 @@ redisContext *redisConnectUnix(const char *path);
 redisContext *redisConnectUnixWithTimeout(const char *path, struct timeval tv);
 redisContext *redisConnectUnixNonBlock(const char *path);
 int redisSetTimeout(redisContext *c, struct timeval tv);
+int redisEnableKeepAlive(redisContext *c);
 void redisFree(redisContext *c);
 int redisBufferRead(redisContext *c);
 int redisBufferWrite(redisContext *c, int *done);

--- a/net.c
+++ b/net.c
@@ -113,9 +113,10 @@ static int redisSetBlocking(redisContext *c, int fd, int blocking) {
     return REDIS_OK;
 }
 
-static int redisKeepAlive(redisContext *c,int fd,int interval) {
+int redisKeepAlive(redisContext *c, int interval) {
     int val = 1;
-	
+    int fd = c->fd;
+
     if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) == -1){
         __redisSetError(c,REDIS_ERR_OTHER,strerror(errno));
         return REDIS_ERR;
@@ -142,8 +143,6 @@ static int redisKeepAlive(redisContext *c,int fd,int interval) {
 
     return REDIS_OK;
 }
-
-
 
 static int redisSetTcpNoDelay(redisContext *c, int fd) {
     int yes = 1;
@@ -272,8 +271,6 @@ int redisContextConnectTcp(redisContext *c, const char *addr, int port, struct t
         if (blocking && redisSetBlocking(c,s,1) != REDIS_OK)
             goto error;
         if (redisSetTcpNoDelay(c,s) != REDIS_OK)
-            goto error;
-        if (redisKeepAlive(c,s,REDIS_KEEPALIVE_INTERVAL) != REDIS_OK)
             goto error;
 
         c->fd = s;

--- a/net.h
+++ b/net.h
@@ -43,5 +43,6 @@ int redisCheckSocketError(redisContext *c, int fd);
 int redisContextSetTimeout(redisContext *c, struct timeval tv);
 int redisContextConnectTcp(redisContext *c, const char *addr, int port, struct timeval *timeout);
 int redisContextConnectUnix(redisContext *c, const char *path, struct timeval *timeout);
+int redisKeepAlive(redisContext *c, int interval);
 
 #endif


### PR DESCRIPTION
redisKeepAlive: After connected, if no command was send to redis for a long time, the connection will be lost, this patch keep client alive with redis-server.
