### PR TITLE
Fix possible uninitialized value access due to strerror_r error

### DIFF
--- a/net.c
+++ b/net.c
@@ -55,7 +55,7 @@
 void __redisSetError(redisContext *c, int type, const char *str);
 
 static void __redisSetErrorFromErrno(redisContext *c, int type, const char *prefix) {
-    char buf[128];
+    char buf[128] = { 0 };
     size_t len = 0;
 
     if (prefix != NULL)


### PR DESCRIPTION
When strerror_r function returns error buf variable stays uninitialized. This variable can in turn be passed to strlen inside __reditSetError function, which causes problems. It doesn't happen often, but I've had few cases like that.
