### PR TITLE
Made example-ae work again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ hiredis-example-ae:
 	@false
 else
 hiredis-example-ae: example-ae.c adapters/ae.h $(STLIBNAME)
-	$(CC) -o $@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I$(AE_DIR) $(AE_DIR)/ae.o $(AE_DIR)/zmalloc.o example-ae.c $(STLIBNAME)
+	$(CC) -o $@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I$(AE_DIR) $(AE_DIR)/ae.o $(AE_DIR)/zmalloc.o $(AE_DIR)/../deps/jemalloc/lib/libjemalloc.a -pthread example-ae.c $(STLIBNAME)
 endif
 
 hiredis-%: %.o $(STLIBNAME)

--- a/example-ae.c
+++ b/example-ae.c
@@ -32,6 +32,8 @@ void disconnectCallback(const redisAsyncContext *c, int status) {
         return;
     }
     printf("Disconnected...\n");
+
+    aeStop(loop);
 }
 
 int main (int argc, char **argv) {
@@ -44,7 +46,7 @@ int main (int argc, char **argv) {
         return 1;
     }
 
-    loop = aeCreateEventLoop();
+    loop = aeCreateEventLoop(64);
     redisAeAttach(loop, c);
     redisAsyncSetConnectCallback(c,connectCallback);
     redisAsyncSetDisconnectCallback(c,disconnectCallback);


### PR DESCRIPTION
Fixed the recent change to `aeCreateEventLoop()` and added the missing jemalloc and pthread libraries.
