### PR TITLE
Fix "host cannot be resolved" test

### DIFF
--- a/test.c
+++ b/test.c
@@ -293,6 +293,7 @@ static void test_blocking_connection_errors(void) {
         (strcmp(c->errstr,"Name or service not known") == 0 ||
          strcmp(c->errstr,"Can't resolve: idontexist.local") == 0 ||
          strcmp(c->errstr,"nodename nor servname provided, or not known") == 0 ||
+         strcmp(c->errstr,"No address associated with hostname") == 0 ||
          strcmp(c->errstr,"no address associated with name") == 0));
     redisFree(c);
 


### PR DESCRIPTION
## Introduction

On my machine (`Ubuntu 10.04 LTS`), gai_strerror function (https://github.com/redis/hiredis/blob/master/net.c#L266) generates "No address associated with hostname" error message, when the hostname cannot be resolved.
