### PR TITLE
Make pointer cast explicit to compile from C++.

### DIFF
--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -11,6 +11,7 @@ typedef struct redisLibuvEvents {
   int                events;
 } redisLibuvEvents;
 
+int redisLibuvAttach(redisAsyncContext*, uv_loop_t*);
 
 static void redisLibuvPoll(uv_poll_t* handle, int status, int events) {
   redisLibuvEvents* p = (redisLibuvEvents*)handle->data;


### PR DESCRIPTION
Relying on the implicit cast from void\* to redisLibuvEvents\* causes compilation errors in C++ since this isn't allowed. This should not change any runtime semantics.
