### PR TITLE
Define redisLibuvAttach as static

### DIFF
--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -86,7 +86,7 @@ static void redisLibuvCleanup(void *privdata) {
 }
 
 
-int redisLibuvAttach(redisAsyncContext* ac, uv_loop_t* loop) {
+static int redisLibuvAttach(redisAsyncContext* ac, uv_loop_t* loop) {
   redisContext *c = &(ac->c);
 
   if (ac->ev.data != NULL) {


### PR DESCRIPTION
If multiple source files in the same project include `adapters/libuv.h`, at the moment this will cause a linker error complaining that the `redisLibuvAttach` symbol is defined multiple times.

This pull request defines it as `static` to prevent this.
