### PR TITLE
use echo -e when creating test server config in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test: hiredis-test
 	./hiredis-test
 
 check: hiredis-test
-	echo \
+	echo -e \
 		"daemonize yes\n" \
 		"pidfile /tmp/hiredis-test-redis.pid\n" \
 		"port 56379\n" \


### PR DESCRIPTION
on arch linux (and probably other distros) bash, echo does not interpret escape sequences by default.
