### PR TITLE
Fix potential undefined struct read

### DIFF
--- a/async.c
+++ b/async.c
@@ -391,7 +391,7 @@ static int __redisGetSubscribeCallback(redisAsyncContext *ac, redisReply *reply,
 
 void redisProcessCallbacks(redisAsyncContext *ac) {
     redisContext *c = &(ac->c);
-    redisCallback cb;
+    redisCallback cb = {NULL, NULL, NULL};
     void *reply = NULL;
     int status;
 


### PR DESCRIPTION
All the assignments to cb are inside conditionals, so it's
vaguely possible it never gets initialized before we try
to read from it with (cb.fn == NULL).

Condition discovered with scan-build.

All tests pass.
