### PR TITLE
Provide sink for formatted commnad allocated by hiredis library

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -973,6 +973,13 @@ int redisFormatCommandArgv(char **target, int argc, const char **argv, const siz
     return totlen;
 }
 
+int freeRedisCommand(char **cmd) {
+    if (*cmd != NULL) {
+        free(*cmd);
+        *cmd = NULL;
+    }
+}
+
 void __redisSetError(redisContext *c, int type, const char *str) {
     size_t len;
 

--- a/hiredis.h
+++ b/hiredis.h
@@ -161,6 +161,7 @@ void freeReplyObject(void *reply);
 int redisvFormatCommand(char **target, const char *format, va_list ap);
 int redisFormatCommand(char **target, const char *format, ...);
 int redisFormatCommandArgv(char **target, int argc, const char **argv, const size_t *argvlen);
+int freeRedisCommand(char **cmd);
 
 /* Context for a connection to Redis */
 typedef struct redisContext {


### PR DESCRIPTION
Command formatting functions allocate memory using 'malloc' and caller is responsible for freeing this memory. However, it can cause all sort of problems, if caller uses his own 'free', because it crosses shared library boundaries. Shared library has to provide sink function, which will call the correct version of 'free'.