### PR TITLE
Fix adapters/libuv.h

### DIFF
--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -11,7 +11,6 @@ typedef struct redisLibuvEvents {
   int                events;
 } redisLibuvEvents;
 
-int redisLibuvAttach(redisAsyncContext*, uv_loop_t*);
 
 static void redisLibuvPoll(uv_poll_t* handle, int status, int events) {
   redisLibuvEvents* p = (redisLibuvEvents*)handle->data;

--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -1,5 +1,6 @@
 #ifndef __HIREDIS_LIBUV_H__
 #define __HIREDIS_LIBUV_H__
+#include <stdlib.h>
 #include <uv.h>
 #include "../hiredis.h"
 #include "../async.h"


### PR DESCRIPTION
The `redisLibuvAttach` function prototype causes redeclaration errors because it's not declared static. It's also completely unnecessary, so just get rid of it.

Implicit declaration of `free` in `on_close` also can cause compilation errors. Include `stdlib.h` to resolve potential issues.