### PR TITLE
Static declaration of 'redisLibuvAttach'

### DIFF
--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -11,7 +11,7 @@ typedef struct redisLibuvEvents {
   int                events;
 } redisLibuvEvents;
 
-int redisLibuvAttach(redisAsyncContext*, uv_loop_t*);
+static int redisLibuvAttach(redisAsyncContext*, uv_loop_t*);
 
 static void redisLibuvPoll(uv_poll_t* handle, int status, int events) {
   redisLibuvEvents* p = (redisLibuvEvents*)handle->data;


### PR DESCRIPTION
Fix static declaration of 'redisLibuvAttach' follows non-static declaration