### PR TITLE
Increase maximum SDS size

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -197,7 +197,7 @@ size_t sdsAllocSize(sds s) {
  * ... check for nread <= 0 and handle it ...
  * sdsIncrLen(s, nread);
  */
-void sdsIncrLen(sds s, int incr) {
+void sdsIncrLen(sds s, long incr) {
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
 
     assert(sh->free >= incr);

--- a/sds.h
+++ b/sds.h
@@ -39,8 +39,8 @@
 typedef char *sds;
 
 struct sdshdr {
-    int len;
-    int free;
+    unsigned int len;
+    unsigned int free;
     char buf[];
 };
 
@@ -94,7 +94,7 @@ sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
 
 /* Low level functions exposed to the user API */
 sds sdsMakeRoomFor(sds s, size_t addlen);
-void sdsIncrLen(sds s, int incr);
+void sdsIncrLen(sds s, long incr);
 sds sdsRemoveFreeSpace(sds s);
 size_t sdsAllocSize(sds s);
 


### PR DESCRIPTION
SDS sizes can never be negative, so it's safe to double their
capacity from 2 GB to 4 GB.

This helps extend some edge cases where people request comically large results from Redis.  Better to handle as much data as we can without running out of space.