### PR TITLE
Fix getaddrinfo() memory leak

### DIFF
--- a/net.c
+++ b/net.c
@@ -300,6 +300,7 @@ static int _redisContextConnectTcp(redisContext *c, const char *addr, int port,
                     break;
                 }
             }
+            freeaddrinfo(bservinfo);
             if (!bound) {
                 char buf[128];
                 snprintf(buf,sizeof(buf),"Can't bind socket: %s",strerror(errno));


### PR DESCRIPTION
See antirez/redis#2012 for the leak causing unbounded memory growth.

This leak was fixed in the Redis anet.c version of network code, but since the hiredis version is essentially the same code copy/paste'd (which came first?), we need to apply the fix here too.
