### PR TITLE
Add timeout feature on the async connection

### DIFF
--- a/async.c
+++ b/async.c
@@ -147,15 +147,9 @@ static void __redisAsyncCopyError(redisAsyncContext *ac) {
     ac->errstr = c->errstr;
 }
 
-redisAsyncContext *redisAsyncConnect(const char *ip, int port) {
-    redisContext *c;
-    redisAsyncContext *ac;
-
-    c = redisConnectNonBlock(ip,port);
-    if (c == NULL)
-        return NULL;
-
-    ac = redisAsyncInitialize(c);
+static redisAsyncContext *__redisAsyncConnectContextFinalize(redisContext *c) {
+    redisAsyncContext *ac = redisAsyncInitialize(c);
+    
     if (ac == NULL) {
         redisFree(c);
         return NULL;
@@ -163,6 +157,26 @@ redisAsyncContext *redisAsyncConnect(const char *ip, int port) {
 
     __redisAsyncCopyError(ac);
     return ac;
+}
+
+redisAsyncContext *redisAsyncConnect(const char *ip, int port) {
+    redisContext *c;
+
+    c = redisConnectNonBlock(ip,port);
+    if (c == NULL)
+        return NULL;
+
+    return __redisAsyncConnectContextFinalize(c);
+}
+
+redisAsyncContext *redisAsyncConnectWithTimeout(const char *ip, int port, const struct timeval timeout) {
+    redisContext *c;
+
+    c = redisConnectNonBlockWithTimeout(ip,port,timeout);
+    if (c == NULL)
+        return NULL;
+
+    return __redisAsyncConnectContextFinalize(c);
 }
 
 redisAsyncContext *redisAsyncConnectBind(const char *ip, int port,

--- a/async.h
+++ b/async.h
@@ -102,6 +102,7 @@ typedef struct redisAsyncContext {
 
 /* Functions that proxy to hiredis */
 redisAsyncContext *redisAsyncConnect(const char *ip, int port);
+redisAsyncContext *redisAsyncConnectWithTimeout(const char *ip, int port, const struct timeval timeout);
 redisAsyncContext *redisAsyncConnectBind(const char *ip, int port, const char *source_addr);
 redisAsyncContext *redisAsyncConnectUnix(const char *path);
 int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn);

--- a/hiredis.c
+++ b/hiredis.c
@@ -1061,6 +1061,18 @@ redisContext *redisConnectNonBlock(const char *ip, int port) {
     return c;
 }
 
+redisContext *redisConnectNonBlockWithTimeout(const char *ip, int port, const struct timeval tv) {
+    redisContext *c;
+
+    c = redisContextInit();
+    if (c == NULL)
+        return NULL;
+
+    c->flags &= ~REDIS_BLOCK;
+    redisContextConnectTcp(c,ip,port,&tv);
+    return c;
+}
+
 redisContext *redisConnectBindNonBlock(const char *ip, int port,
                                        const char *source_addr) {
     redisContext *c = redisContextInit();

--- a/hiredis.h
+++ b/hiredis.h
@@ -175,6 +175,7 @@ typedef struct redisContext {
 redisContext *redisConnect(const char *ip, int port);
 redisContext *redisConnectWithTimeout(const char *ip, int port, const struct timeval tv);
 redisContext *redisConnectNonBlock(const char *ip, int port);
+redisContext *redisConnectNonBlockWithTimeout(const char *ip, int port, const struct timeval tv);
 redisContext *redisConnectBindNonBlock(const char *ip, int port, const char *source_addr);
 redisContext *redisConnectUnix(const char *path);
 redisContext *redisConnectUnixWithTimeout(const char *path, const struct timeval tv);


### PR DESCRIPTION
The redisAsyncConnect function is missing a way to transfer a timevalstruct to the underlying connect function. If the target server drops silently every tcp packet, the call is blocked until something happens. But the underlying connection function can take timeval as an argument for a timeout, there is just no way to use it through redisAsyncConnect.
