### PR TITLE
Fix make install again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ PREFIX?=/usr/local
 INCLUDE_PATH?=include/hiredis
 LIBRARY_PATH?=lib
 PKGCONF_PATH?=pkgconfig
-INSTALL_INCLUDE_PATH= $(DESTDIR)$(PREFIX)/$(INCLUDE_PATH)
-INSTALL_LIBRARY_PATH= $(DESTDIR)$(PREFIX)/$(LIBRARY_PATH)
+INSTALL_INCLUDE_PATH= $(PREFIX)/$(INCLUDE_PATH)
+INSTALL_LIBRARY_PATH= $(PREFIX)/$(LIBRARY_PATH)
 INSTALL_PKGCONF_PATH= $(INSTALL_LIBRARY_PATH)/$(PKGCONF_PATH)
 
 # redis-server configuration used for testing
@@ -150,25 +150,25 @@ INSTALL?= cp -a
 $(PKGCONFNAME): hiredis.h
 	@echo "Generating $@ for pkgconfig..."
 	@echo prefix=$(PREFIX) > $@
-	@echo exec_prefix=$${prefix} >> $@
+	@echo exec_prefix=\$${prefix} >> $@
 	@echo libdir=$(INSTALL_LIBRARY_PATH) >> $@
 	@echo includedir=$(INSTALL_INCLUDE_PATH) >> $@
 	@echo >> $@
 	@echo Name: hiredis >> $@
 	@echo Description: Minimalistic C client library for Redis. >> $@
 	@echo Version: $(HIREDIS_MAJOR).$(HIREDIS_MINOR).$(HIREDIS_PATCH) >> $@
-	@echo Libs: -L$${libdir} -lhiredis >> $@
-	@echo Cflags: -I$${includedir} -D_FILE_OFFSET_BITS=64 >> $@
+	@echo Libs: -L\$${libdir} -lhiredis >> $@
+	@echo Cflags: -I\$${includedir} -D_FILE_OFFSET_BITS=64 >> $@
 
-install: $(DYLIBNAME) $(STLIBNAME)
-	mkdir -p $(INSTALL_INCLUDE_PATH) $(INSTALL_LIBRARY_PATH)
-	$(INSTALL) hiredis.h async.h read.h sds.h adapters $(INSTALL_INCLUDE_PATH)
-	$(INSTALL) $(DYLIBNAME) $(INSTALL_LIBRARY_PATH)/$(DYLIB_MINOR_NAME)
-	cd $(INSTALL_LIBRARY_PATH) && ln -sf $(DYLIB_MINOR_NAME) $(DYLIB_MAJOR_NAME)
-	cd $(INSTALL_LIBRARY_PATH) && ln -sf $(DYLIB_MAJOR_NAME) $(DYLIBNAME)
-	$(INSTALL) $(STLIBNAME) $(INSTALL_LIBRARY_PATH)
-	mkdir -p $(INSTALL_PKGCONF_PATH)
-	$(INSTALL) $(PKGCONFNAME) $(INSTALL_PKGCONF_PATH)
+install: $(DYLIBNAME) $(STLIBNAME) $(PKGCONFNAME)
+	mkdir -p $(DESTDIR)$(INSTALL_INCLUDE_PATH) $(DESTDIR)$(INSTALL_LIBRARY_PATH)
+	$(INSTALL) hiredis.h async.h read.h sds.h adapters $(DESTDIR)$(INSTALL_INCLUDE_PATH)
+	$(INSTALL) $(DYLIBNAME) $(DESTDIR)$(INSTALL_LIBRARY_PATH)/$(DYLIB_MINOR_NAME)
+	cd $(DESTDIR)$(INSTALL_LIBRARY_PATH) && ln -sf $(DYLIB_MINOR_NAME) $(DYLIB_MAJOR_NAME)
+	cd $(DESTDIR)$(INSTALL_LIBRARY_PATH) && ln -sf $(DYLIB_MAJOR_NAME) $(DYLIBNAME)
+	$(INSTALL) $(STLIBNAME) $(DESTDIR)$(INSTALL_LIBRARY_PATH)
+	mkdir -p $(DESTDIR)$(INSTALL_PKGCONF_PATH)
+	$(INSTALL) $(PKGCONFNAME) $(DESTDIR)$(INSTALL_PKGCONF_PATH)
 
 32bit:
 	@echo ""


### PR DESCRIPTION
For real, the commit 4355ab3c8fa7ad98b8a21267f84ebbaf47e2d2f8 messed up with me here. At least I couldn't build 0.12.0+ for Fedora without harsh patch.

It installed files to somewhere outside first, and then destdir was introduced but abused. Meanwhile the pkgconfig file was broken, the original echo line in makefile didn't escape the dollar sign so the final generated file would ignore the ${includedir} and ${libdir} as they were empty. I know modern compiler is smart but we still need some pedantic styles as they are not matured yet on such style it used.

This patch:

1. Use $(DESTDIR) only in install stage.
2. Change pkgconfig file from:

Libs: -L -lhiredis
Cflags: -I -D_FILE_OFFSET_BITS=64

to

Libs: -L${libdir} -lhiredis
Cflags: -I${includedir} -D_FILE_OFFSET_BITS=64




3. $(PKGCONFNAME) stage is needed for install stage.