### PR TITLE
Fix hiredis.h include path in example.c

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <hiredis.h>
+#include <hiredis/hiredis.h>
 
 int main(int argc, char **argv) {
     unsigned int j;


### PR DESCRIPTION
Without this change, examples/example.c fails to compile.
```
[kp@trantor examples (master)]$ gcc -lhiredis example.c 
example.c:5:21: fatal error: hiredis.h: No such file or directory
 #include <hiredis.h>
                     ^
compilation terminated.
```
Signed-off-by: Krishnan Parthasarathi <kp@gluster.org>