### PR TITLE
Fix pkgconf file: escaping needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,8 @@ $(PKGCONFNAME): hiredis.h
 	@echo Name: hiredis >> $@
 	@echo Description: Minimalistic C client library for Redis. >> $@
 	@echo Version: $(HIREDIS_MAJOR).$(HIREDIS_MINOR).$(HIREDIS_PATCH) >> $@
-	@echo Libs: -L$${libdir} -lhiredis >> $@
-	@echo Cflags: -I$${includedir} -D_FILE_OFFSET_BITS=64 >> $@
+	@echo Libs: -L\$${libdir} -lhiredis >> $@
+	@echo Cflags: -I\$${includedir} -D_FILE_OFFSET_BITS=64 >> $@
 
 install: $(DYLIBNAME) $(STLIBNAME)
 	mkdir -p $(INSTALL_INCLUDE_PATH) $(INSTALL_LIBRARY_PATH)


### PR DESCRIPTION
Due to the various processors going over the command, we need more
escaping.

1) Make parses it, so $${libdir} becomes ${libdir}
2) 'shell' parses it for the 'echo command', whereas echo ${libdir}
would be an empty string; escape it as \${libdir} to ensure we get what
we want.