### PR TITLE
Add PKGCONFNAME to install dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ $(PKGCONFNAME): hiredis.h
 	@echo Libs: -L\$${libdir} -lhiredis >> $@
 	@echo Cflags: -I\$${includedir} -D_FILE_OFFSET_BITS=64 >> $@
 
-install: $(DYLIBNAME) $(STLIBNAME)
+install: $(DYLIBNAME) $(STLIBNAME) $(PKGCONFNAME)
 	mkdir -p $(INSTALL_INCLUDE_PATH) $(INSTALL_LIBRARY_PATH)
 	$(INSTALL) hiredis.h async.h read.h sds.h adapters $(INSTALL_INCLUDE_PATH)
 	$(INSTALL) $(DYLIBNAME) $(INSTALL_LIBRARY_PATH)/$(DYLIB_MINOR_NAME)


### PR DESCRIPTION
Attempting to use the install target before the make target works fine,
except for the missing pkgconfig file.  Adding that file to the
dependencies for the install target to make sure it gets created first.