### PR TITLE
Renamed redisContext struct member 'unix' to 'unix_sock' to avoid encoun...

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -602,7 +602,7 @@ static redisContext *redisContextInit(void) {
     c->reader = redisReaderCreate();
     c->tcp.host = NULL;
     c->tcp.source_addr = NULL;
-    c->unix.path = NULL;
+    c->unix_sock.path = NULL;
     c->timeout = NULL;
 
     if (c->obuf == NULL || c->reader == NULL) {
@@ -626,8 +626,8 @@ void redisFree(redisContext *c) {
         free(c->tcp.host);
     if (c->tcp.source_addr)
         free(c->tcp.source_addr);
-    if (c->unix.path)
-        free(c->unix.path);
+    if (c->unix_sock.path)
+        free(c->unix_sock.path);
     if (c->timeout)
         free(c->timeout);
     free(c);
@@ -658,7 +658,7 @@ int redisReconnect(redisContext *c) {
         return redisContextConnectBindTcp(c, c->tcp.host, c->tcp.port,
                 c->timeout, c->tcp.source_addr);
     } else if (c->connection_type == REDIS_CONN_UNIX) {
-        return redisContextConnectUnix(c, c->unix.path, c->timeout);
+        return redisContextConnectUnix(c, c->unix_sock.path, c->timeout);
     } else {
         /* Something bad happened here and shouldn't have. There isn't
            enough information in the context to reconnect. */

--- a/hiredis.h
+++ b/hiredis.h
@@ -155,7 +155,7 @@ typedef struct redisContext {
 
     struct {
         char *path;
-    } unix;
+    } unix_sock;
 
 } redisContext;
 

--- a/net.c
+++ b/net.c
@@ -422,8 +422,8 @@ int redisContextConnectUnix(redisContext *c, const char *path, const struct time
         return REDIS_ERR;
 
     c->connection_type = REDIS_CONN_UNIX;
-    if (c->unix.path != path)
-        c->unix.path = strdup(path);
+    if (c->unix_sock.path != path)
+        c->unix_sock.path = strdup(path);
 
     if (timeout) {
         if (c->timeout != timeout) {


### PR DESCRIPTION
...tering defined constant 'unix' in GNU C environment (see commit d8145d79ce715054980938c751067ebaa541573c).

Not all code using hiredis can compile using '-std=c99', and/or not all users are able to easily make that change to the build process of various open-source projects, so it is more pragmatic to choose a different identifier that does not impose this requirement.