### PR TITLE
redisBufferRead: Clear REDIS_CONNECTED flag when connection is closed

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -808,6 +808,7 @@ int redisBufferRead(redisContext *c) {
             return REDIS_ERR;
         }
     } else if (nread == 0) {
+        c->flags &= ~REDIS_CONNECTED;
         __redisSetError(c,REDIS_ERR_EOF,"Server closed the connection");
         return REDIS_ERR;
     } else {


### PR DESCRIPTION
The redisContext flag REDIS_CONNECT is not cleared when REDIS_ERR_EOF is returned in redisBufferRead. For public API the c->err = REDIS_ERR_EOF is not known. Clearing the REDIS_CONNECT flag is a good practice.