### PR TITLE
undefined reference to `clock_gettime'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ hiredis-example-libuv:
 	@false
 else
 hiredis-example-libuv: examples/example-libuv.c adapters/libuv.h $(STLIBNAME)
-	$(CC) -o examples/$@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I. -I$(LIBUV_DIR)/include $< $(LIBUV_DIR)/.libs/libuv.a -lpthread $(STLIBNAME)
+	$(CC) -o examples/$@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I. -I$(LIBUV_DIR)/include $< $(LIBUV_DIR)/.libs/libuv.a -lpthread -lrt $(STLIBNAME)
 endif
 
 hiredis-example: examples/example.c $(STLIBNAME)


### PR DESCRIPTION
fix link error while run "make hiredis-example-libuv":

undefined reference to `clock_gettime'
undefined reference to `clock_getres'