### PR TITLE
Fix clang-analyzer warnings

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -429,6 +429,8 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
     int i;
     va_list ap;
 
+    if (sh == NULL) return NULL;
+
     va_start(ap,fmt);
     f = fmt;    /* Next format specifier byte to process. */
     i = initlen; /* Position of the next byte to write to dest str. */
@@ -442,6 +444,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
         if (sh->free == 0) {
             s = sdsMakeRoomFor(s,1);
             sh = (void*) (s-(sizeof(struct sdshdr)));
+            if (sh == NULL) return NULL;
         }
 
         switch(*f) {
@@ -456,6 +459,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
                 if (sh->free < l) {
                     s = sdsMakeRoomFor(s,l);
                     sh = (void*) (s-(sizeof(struct sdshdr)));
+                    if (sh == NULL) return NULL;
                 }
                 memcpy(s+i,str,l);
                 sh->len += l;
@@ -474,6 +478,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
                     if (sh->free < l) {
                         s = sdsMakeRoomFor(s,l);
                         sh = (void*) (s-(sizeof(struct sdshdr)));
+                        if (sh == NULL) return NULL;
                     }
                     memcpy(s+i,buf,l);
                     sh->len += l;
@@ -496,6 +501,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
                     if (sh->free < l) {
                         s = sdsMakeRoomFor(s,l);
                         sh = (void*) (s-(sizeof(struct sdshdr)));
+                        if (sh == NULL) return NULL;
                     }
                     memcpy(s+i,buf,l);
                     sh->len += l;
@@ -544,6 +550,8 @@ void sdstrim(sds s, const char *cset) {
     struct sdshdr *sh = (void*) (s-sizeof *sh);
     char *start, *end, *sp, *ep;
     size_t len;
+
+    if (sh == NULL) return;
 
     sp = start = s;
     ep = end = s+sdslen(s)-1;
@@ -908,7 +916,7 @@ sds *sdssplitargs(const char *line, int *argc) {
             current = NULL;
         } else {
             /* Even on empty input string return something not NULL. */
-            if (vector == NULL) vector = malloc(sizeof(void*));
+            if (vector == NULL) vector = (char**)malloc(sizeof(char*));
             return vector;
         }
     }

--- a/sds.h
+++ b/sds.h
@@ -49,11 +49,13 @@ struct sdshdr {
 
 static inline size_t sdslen(const sds s) {
     struct sdshdr *sh = (struct sdshdr *)(s-sizeof *sh);
+    if (sh == NULL) return 0;
     return sh->len;
 }
 
 static inline size_t sdsavail(const sds s) {
     struct sdshdr *sh = (struct sdshdr *)(s-sizeof *sh);
+    if (sh == NULL) return 0;
     return sh->free;
 }
 


### PR DESCRIPTION
Hi,

I'm using clang-analyzer for my project and it found a few issues in hiredis. This PR fixes them.

here below the output of scan-build make.

Kind regards,

Rik

```
scan-build: Using '/usr/lib/llvm-3.5/bin/clang' for static analysis
/usr/share/clang/scan-build-3.5/ccc-analyzer -std=c99 -pedantic -c -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  net.c
/usr/share/clang/scan-build-3.5/ccc-analyzer -std=c99 -pedantic -c -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  hiredis.c
/usr/share/clang/scan-build-3.5/ccc-analyzer -std=c99 -pedantic -c -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  sds.c
In file included from sds.c:37:
./sds.h:52:12: warning: Access to field 'len' results in a dereference of a null pointer (loaded from variable 'sh')
    return sh->len;
           ^~~~~~~
sds.c:456:21: warning: Access to field 'free' results in a dereference of a null pointer (loaded from variable 'sh')
                if (sh->free < l) {
                    ^~~~~~~~
sds.c:461:25: warning: Access to field 'len' results in a dereference of a null pointer (loaded from variable 'sh')
                sh->len += l;
                ~~      ^
sds.c:474:25: warning: Access to field 'free' results in a dereference of a null pointer (loaded from variable 'sh')
                    if (sh->free < l) {
                        ^~~~~~~~
sds.c:479:29: warning: Access to field 'len' results in a dereference of a null pointer (loaded from variable 'sh')
                    sh->len += l;
                    ~~      ^
sds.c:496:25: warning: Access to field 'free' results in a dereference of a null pointer (loaded from variable 'sh')
                    if (sh->free < l) {
                        ^~~~~~~~
sds.c:501:29: warning: Access to field 'len' results in a dereference of a null pointer (loaded from variable 'sh')
                    sh->len += l;
                    ~~      ^
sds.c:911:42: warning: Result of 'malloc' is converted to a pointer of type 'char *', which is incompatible with sizeof operand type 'void *'
            if (vector == NULL) vector = malloc(sizeof(void*));
                                         ^~~~~~ ~~~~~~~~~~~~~
8 warnings generated.
/usr/share/clang/scan-build-3.5/ccc-analyzer -std=c99 -pedantic -c -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  async.c
/usr/share/clang/scan-build-3.5/ccc-analyzer -std=c99 -pedantic -c -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  read.c
In file included from read.c:44:
./sds.h:52:12: warning: Access to field 'len' results in a dereference of a null pointer (loaded from variable 'sh')
    return sh->len;
           ^~~~~~~
1 warning generated.
/usr/share/clang/scan-build-3.5/ccc-analyzer -shared -Wl,-soname,libhiredis.so.0.13 -o libhiredis.so  net.o hiredis.o sds.o async.o read.o
ar rcs libhiredis.a net.o hiredis.o sds.o async.o read.o
/usr/share/clang/scan-build-3.5/ccc-analyzer -std=c99 -pedantic -c -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  test.c
/usr/share/clang/scan-build-3.5/ccc-analyzer -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  -o hiredis-test   test.o libhiredis.a
Generating hiredis.pc for pkgconfig...
scan-build: 7 bugs found.
```