### PR TITLE
Add FreeBSD message to test_blocking_connection_errors.

### DIFF
--- a/test.c
+++ b/test.c
@@ -351,6 +351,7 @@ static void test_blocking_connection_errors(void) {
          strcmp(c->errstr,"nodename nor servname provided, or not known") == 0 ||
          strcmp(c->errstr,"No address associated with hostname") == 0 ||
          strcmp(c->errstr,"Temporary failure in name resolution") == 0 ||
+         strcmp(c->errstr,"hostname nor servname provided, or not known") == 0 ||
          strcmp(c->errstr,"no address associated with name") == 0));
     redisFree(c);
 


### PR DESCRIPTION
I added a missing error message so that tests pass on FreeBSD too.