### PR TITLE
Add redisFormattedCommand() as an option for hiredis sync calls.

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -1019,3 +1019,9 @@ void *redisCommandArgv(redisContext *c, int argc, const char **argv, const size_
         return NULL;
     return __redisBlockForReply(c);
 }
+
+void *redisFormattedCommand(redisContext *c, const char *cmd, size_t len) {
+    if (redisAppendFormattedCommand(c,cmd,len) != REDIS_OK)
+        return NULL;
+    return __redisBlockForReply(c);
+}

--- a/hiredis.h
+++ b/hiredis.h
@@ -215,6 +215,7 @@ int redisAppendCommandArgv(redisContext *c, int argc, const char **argv, const s
 void *redisvCommand(redisContext *c, const char *format, va_list ap);
 void *redisCommand(redisContext *c, const char *format, ...);
 void *redisCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen);
+void *redisFormattedCommand(redisContext *c, const char *cmd, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Sometimes we need to pre-format the incoming command for decision making, before we actually make the hiredis command call.

Since we already have redisAsyncFormattedCommand() for hiredis async calls; it is also useful to have redisFormattedCommand() for hiredis sync calls.
