### PR TITLE
Try to prevent integer overflow in sds length.

### DIFF
--- a/read.c
+++ b/read.c
@@ -444,6 +444,7 @@ void redisReaderFree(redisReader *r) {
 
 int redisReaderFeed(redisReader *r, const char *buf, size_t len) {
     sds newbuf;
+    int status = SDS_OK;
 
     /* Return early when this reader is in an erroneous state. */
     if (r->err)
@@ -461,7 +462,9 @@ int redisReaderFeed(redisReader *r, const char *buf, size_t len) {
             assert(r->buf != NULL);
         }
 
-        newbuf = sdscatlen(r->buf,buf,len);
+        newbuf = sdscatlen(r->buf,buf,len,&status);
+        if (status != SDS_OK)
+            return REDIS_ERR;
         if (newbuf == NULL) {
             __redisReaderSetErrorOOM(r);
             return REDIS_ERR;

--- a/sds.h
+++ b/sds.h
@@ -31,6 +31,12 @@
 #ifndef __SDS_H
 #define __SDS_H
 
+#define SDS_OK 0
+#define SDS_ERR_LEN 1
+#define SDS_ERR_OOM 2
+#define SDS_ERR_OTHER 3
+#define SDS_ERR -1
+
 #define SDS_MAX_PREALLOC (1024*1024)
 
 #include <sys/types.h>
@@ -38,6 +44,10 @@
 #ifdef _MSC_VER
 #include "win32.h"
 #endif
+
+#include <limits.h>
+/* this had better match type of sdshdr.len */
+#define SDS_MAX_LEN INT_MAX
 
 typedef char *sds;
 
@@ -57,47 +67,47 @@ static inline size_t sdsavail(const sds s) {
     return sh->free;
 }
 
-sds sdsnewlen(const void *init, size_t initlen);
-sds sdsnew(const char *init);
+sds sdsnewlen(const void *init, size_t initlen, int *status);
+sds sdsnew(const char *init, int *status);
 sds sdsempty(void);
 size_t sdslen(const sds s);
 sds sdsdup(const sds s);
 void sdsfree(sds s);
 size_t sdsavail(const sds s);
-sds sdsgrowzero(sds s, size_t len);
-sds sdscatlen(sds s, const void *t, size_t len);
-sds sdscat(sds s, const char *t);
-sds sdscatsds(sds s, const sds t);
-sds sdscpylen(sds s, const char *t, size_t len);
-sds sdscpy(sds s, const char *t);
+sds sdsgrowzero(sds s, size_t len, int *status);
+sds sdscatlen(sds s, const void *t, size_t len, int *status);
+sds sdscat(sds s, const char *t, int *status);
+sds sdscatsds(sds s, const sds t, int *status);
+sds sdscpylen(sds s, const char *t, size_t len, int *status);
+sds sdscpy(sds s, const char *t, int *status);
 
-sds sdscatvprintf(sds s, const char *fmt, va_list ap);
+sds sdscatvprintf(sds s, int *status, const char *fmt, va_list ap);
 #ifdef __GNUC__
-sds sdscatprintf(sds s, const char *fmt, ...)
-    __attribute__((format(printf, 2, 3)));
+sds sdscatprintf(sds s, int *status, const char *fmt, ...)
+    __attribute__((format(printf, 3, 4)));
 #else
-sds sdscatprintf(sds s, const char *fmt, ...);
+sds sdscatprintf(sds s, int *status, const char *fmt, ...);
 #endif
 
-sds sdscatfmt(sds s, char const *fmt, ...);
+sds sdscatfmt(sds s, int *status, char const *fmt, ...);
 void sdstrim(sds s, const char *cset);
 void sdsrange(sds s, int start, int end);
-void sdsupdatelen(sds s);
+void sdsupdatelen(sds s, int *status);
 void sdsclear(sds s);
 int sdscmp(const sds s1, const sds s2);
-sds *sdssplitlen(const char *s, int len, const char *sep, int seplen, int *count);
+sds *sdssplitlen(const char *s, int len, const char *sep, int seplen, int *count, int *status);
 void sdsfreesplitres(sds *tokens, int count);
 void sdstolower(sds s);
 void sdstoupper(sds s);
-sds sdsfromlonglong(long long value);
-sds sdscatrepr(sds s, const char *p, size_t len);
-sds *sdssplitargs(const char *line, int *argc);
+sds sdsfromlonglong(long long value, int *status);
+sds sdscatrepr(sds s, const char *p, size_t len, int *status);
+sds *sdssplitargs(const char *line, int *argc, int *status);
 sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
-sds sdsjoin(char **argv, int argc, char *sep, size_t seplen);
-sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
+sds sdsjoin(char **argv, int argc, char *sep, size_t seplen, int *status);
+sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen, int *status);
 
 /* Low level functions exposed to the user API */
-sds sdsMakeRoomFor(sds s, size_t addlen);
+sds sdsMakeRoomFor(sds s, size_t addlen, int *status);
 void sdsIncrLen(sds s, int incr);
 sds sdsRemoveFreeSpace(sds s);
 size_t sdsAllocSize(sds s);


### PR DESCRIPTION
I encountered integer overflows in sds when using hiredis to send many commands in a pipeline.  These manifested as hard-to-diagnose errors in my application.  I think it would be preferable to try to prevent overflows and fail with an informative error message.  This change affects the sds API substantially; I'm open to alternatives.

Commit message: try to maintain the invariant that
len + free is never larger than the maximum value
of the integer type.  Add new status flag to
several sds commands, setting it to SDS_OK by
default and SDS_ERR_LEN when there is an attempt
to violate this invariant.