### PR TITLE
Prevent buffer overflow when formatting the error

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -98,8 +98,8 @@
          * then GNU strerror_r returned an internal static buffer and we       \
          * need to copy the result into our private buffer. */                 \
         if (err_str != (buf)) {                                                \
-            buf[(len)] = '\0';                                                 \
-            strncat((buf), err_str, ((len) - 1));                              \
+            strncpy((buf), err_str, ((len) - 1));                              \
+            buf[(len)-1] = '\0';                                               \
         }                                                                      \
     } while (0)
 #endif


### PR DESCRIPTION
strncat might copy n+1 bytes (n bytes from the source plus a terminating nul byte).
Also strncat appends after the first found nul byte. But all we pass is
a buffer we might not have zeroed out already.

Closes #380