### PR TITLE
Update README.md to tell about SUBSCRIBE limitations with redisAsyncContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,23 @@ valid for the duration of the callback.
 
 All pending callbacks are called with a `NULL` reply when the context encountered an error.
 
+#### A note on SUBSCRIBE/UNSUBSCRIBE
+
+The asynchronous API is very suitable for `SUBSCRIBE`, since it invokes a callback on a PUBLISH event. 
+This comes with a drawback, which is that once a `SUBSCRIBE` command was issued on a particular context,
+you cannot send any other command to that context other than `(P)SUBSCRIBE`/`UNSUBSCRIBE` until there is 
+no subcription anymore.
+
+What it means in practice, is that this won't work:
+
+```c
+redisAsyncCommand( ctx, onMessage, NULL, "SUBSCRIBE topic" );
+redisAsyncCommand( ctx, onMessage, NULL, "SUBSCRIBE othertopic" ); // Works
+redisAsyncCommand( ctx, onMessage, NULL, "SET myKey 1234" ); // Will fail
+```
+
+The solution here is to manage 2 contexts: one for your subscribtions and another for your usual commands.
+
 ### Disconnecting
 
 An asynchronous connection can be terminated using:


### PR DESCRIPTION
When issuing a SUBSCRIBE command to a `redisAsyncContext`, you cannot send any other command than (P)SUBSCRIBE/UNSUBSCRIBE, until the context has no pending subscriptions.

This updates the README to tell people using HiRedis about this limitation, and the way to compensate for it (by using 2 contexts). The API doesn't hint at this even though it looks like a legitimate usage (place a subscription, expect to be called when a publish is issued, and use the same context to do other operations).

Feel free to enhance my prose..