### PR TITLE
Update read.c

### DIFF
--- a/read.c
+++ b/read.c
@@ -127,7 +127,7 @@ static char *seekNewline(char *s, size_t len) {
      * might not have a trailing NULL character. */
     while (pos < _len) {
         while(pos < _len && s[pos] != '\r') pos++;
-        if (s[pos] != '\r') {
+        if (pos==_len) {
             /* Not found. */
             return NULL;
         } else {


### PR DESCRIPTION
static char *seekNewline(char *s, size_t len)  : 
this function can not parse the string,such as "hello world\r". the case that  the last char is '\r'.