### PR TITLE
fmacros.h: Fix warning when compiled with -Wundef

### DIFF
--- a/fmacros.h
+++ b/fmacros.h
@@ -14,7 +14,7 @@
 #define _XOPEN_SOURCE
 #endif
 
-#if __APPLE__ && __MACH__
+#if defined(__APPLE__) && defined(__MACH__)
 #define _OSX
 #endif
 


### PR DESCRIPTION
When compiling with the flag `-Wundef` the following warning is emitted:

```
[ 40%] Building C object CMakeFiles/hiredis-STATIC.dir/read.c.o
In file included from /data/files/users/jerry/github/hiredis/read.c:33:0:
/data/files/users/jerry/github/hiredis/fmacros.h:17:5: warning: "__APPLE__" is not defined [-Wundef]
 #if __APPLE__ && __MACH__
     ^
In file included from /usr/include/string.h:25:0,
                 from /data/files/users/jerry/github/hiredis/read.c:34:
```