### PR TITLE
sds.h: Fix compiler warning when adding -Wredundant-decls

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -60,10 +60,8 @@ static inline size_t sdsavail(const sds s) {
 sds sdsnewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);
 sds sdsempty(void);
-size_t sdslen(const sds s);
 sds sdsdup(const sds s);
 void sdsfree(sds s);
-size_t sdsavail(const sds s);
 sds sdsgrowzero(sds s, size_t len);
 sds sdscatlen(sds s, const void *t, size_t len);
 sds sdscat(sds s, const char *t);


### PR DESCRIPTION
Fixes:
```
In file included from /data/files/users/jerry/github/hiredis/read.c:44:0:
/data/files/users/jerry/github/hiredis/sds.h:63:8: warning: redundant redeclaration of 'sdslen' [-Wredundant-decls]
 size_t sdslen(const sds s);
        ^
/data/files/users/jerry/github/hiredis/sds.h:50:22: note: previous definition of 'sdslen' was here
 static inline size_t sdslen(const sds s) {
                      ^
/data/files/users/jerry/github/hiredis/sds.h:66:8: warning: redundant redeclaration of 'sdsavail' [-Wredundant-decls]
 size_t sdsavail(const sds s);
        ^
/data/files/users/jerry/github/hiredis/sds.h:55:22: note: previous definition of 'sdsavail' was here
 static inline size_t sdsavail(const sds s) {
                      ^
```