### PR TITLE
test.c: Fix shadowed name with typedef when compiling with -Wshadow

### DIFF
--- a/test.c
+++ b/test.c
@@ -328,12 +328,12 @@ static void test_reply_reader(void) {
 }
 
 static void test_free_null(void) {
-    void *redisContext = NULL;
+    void *redisCtx = NULL;
     void *reply = NULL;
 
     test("Don't fail when redisFree is passed a NULL value: ");
-    redisFree(redisContext);
-    test_cond(redisContext == NULL);
+    redisFree(redisCtx);
+    test_cond(redisCtx == NULL);
 
     test("Don't fail when freeReplyObject is passed a NULL value: ");
     freeReplyObject(reply);


### PR DESCRIPTION
Fixes:
```
/data/files/users/jerry/github/hiredis/test.c: In function 'test_free_null':
/data/files/users/jerry/github/hiredis/test.c:331:11: warning: declaration of 'redisContext' shadows a global declaration [-Wshadow]
     void *redisContext = NULL;
           ^
In file included from /data/files/users/jerry/github/hiredis/test.c:13:0:
/data/files/users/jerry/github/hiredis/hiredis.h:161:3: note: shadowed declaration is here
 } redisContext;
   ^
```