### PR TITLE
fix: Remove backwards compatibility macro's

### DIFF
--- a/read.h
+++ b/read.h
@@ -100,14 +100,9 @@ void redisReaderFree(redisReader *r);
 int redisReaderFeed(redisReader *r, const char *buf, size_t len);
 int redisReaderGetReply(redisReader *r, void **reply);
 
-/* Backwards compatibility, can be removed on big version bump. */
-#define redisReplyReaderCreate redisReaderCreate
-#define redisReplyReaderFree redisReaderFree
-#define redisReplyReaderFeed redisReaderFeed
-#define redisReplyReaderGetReply redisReaderGetReply
-#define redisReplyReaderSetPrivdata(_r, _p) (int)(((redisReader*)(_r))->privdata = (_p))
-#define redisReplyReaderGetObject(_r) (((redisReader*)(_r))->reply)
-#define redisReplyReaderGetError(_r) (((redisReader*)(_r))->errstr)
+#define redisReaderSetPrivdata(_r, _p) (int)(((redisReader*)(_r))->privdata = (_p))
+#define redisReaderGetObject(_r) (((redisReader*)(_r))->reply)
+#define redisReaderGetError(_r) (((redisReader*)(_r))->errstr)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Closes #296

BREAKING CHANGE: This removes the redisReplyReader* functions, which are
                 already replaced by redisReader* functions.
                 It renames `redisReplyReaderSetPrivdata`,
                 `redisReplyReaderGetObject` and `redisReplyReaderGetError`
                 to `redisReaderSetPrivdata`, `redisReaderGetObject`
                 and `redisReaderGetError`.