### PR TITLE
Add C++ example and move old-style cast inlined function into sds.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # This file is released under the BSD license, see the COPYING file
 
 OBJ=net.o hiredis.o sds.o async.o read.o
-EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib
+EXAMPLES=hiredis-example hiredis-example-cpp hiredis-example-libevent hiredis-example-libev hiredis-example-glib
 TESTS=hiredis-test
 LIBNAME=libhiredis
 PKGCONFNAME=hiredis.pc
@@ -42,6 +42,7 @@ OPTIMIZATION?=-O3
 WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings
 DEBUG?= -g -ggdb
 REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG) $(ARCH)
+REAL_CXXFLAGS=$(REAL_CFLAGS) -Wold-style-cast
 REAL_LDFLAGS=$(LDFLAGS) $(ARCH)
 
 DYLIBSUFFIX=so
@@ -135,6 +136,9 @@ endif
 
 hiredis-example: examples/example.c $(STLIBNAME)
 	$(CC) -o examples/$@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I. $< $(STLIBNAME)
+
+hiredis-example-cpp: examples/example.cpp $(STLIBNAME)
+	$(CXX) -o examples/$@ $(REAL_CXXFLAGS) $(REAL_LDFLAGS) -I. $< -pthread $(STLIBNAME)
 
 examples: $(EXAMPLES)
 

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <hiredis.h>
+
+int main(int argc, char **argv) {
+    unsigned int j;
+    redisContext *c;
+    redisReply *reply;
+    const char *hostname = (argc > 1) ? argv[1] : "127.0.0.1";
+    int port = (argc > 2) ? atoi(argv[2]) : 6379;
+
+    struct timeval timeout = { 1, 500000 }; // 1.5 seconds
+    c = redisConnectWithTimeout(hostname, port, timeout);
+    if (c == NULL || c->err) {
+        if (c) {
+            printf("Connection error: %s\n", c->errstr);
+            redisFree(c);
+        } else {
+            printf("Connection error: can't allocate redis context\n");
+        }
+        exit(1);
+    }
+
+    /* PING server */
+    reply = static_cast<redisReply *>(redisCommand(c,"PING"));
+    printf("PING: %s\n", reply->str);
+    freeReplyObject(reply);
+
+    /* Set a key */
+    reply = static_cast<redisReply *>(redisCommand(c,"SET %s %s", "foo", "hello world"));
+    printf("SET: %s\n", reply->str);
+    freeReplyObject(reply);
+
+    /* Set a key using binary safe API */
+    reply = static_cast<redisReply *>(redisCommand(c,"SET %b %b", "bar", 3, "hello", 5));
+    printf("SET (binary API): %s\n", reply->str);
+    freeReplyObject(reply);
+
+    /* Try a GET and two INCR */
+    reply = static_cast<redisReply *>(redisCommand(c,"GET foo"));
+    printf("GET foo: %s\n", reply->str);
+    freeReplyObject(reply);
+
+    reply = static_cast<redisReply *>(redisCommand(c,"INCR counter"));
+    printf("INCR counter: %lld\n", reply->integer);
+    freeReplyObject(reply);
+    /* again ... */
+    reply = static_cast<redisReply *>(redisCommand(c,"INCR counter"));
+    printf("INCR counter: %lld\n", reply->integer);
+    freeReplyObject(reply);
+
+    /* Create a list of numbers, from 0 to 9 */
+    reply = static_cast<redisReply *>(redisCommand(c,"DEL mylist"));
+    freeReplyObject(reply);
+    for (j = 0; j < 10; j++) {
+        char buf[64];
+
+        snprintf(buf,64,"%u",j);
+        reply = static_cast<redisReply *>(redisCommand(c,"LPUSH mylist element-%s", buf));
+        freeReplyObject(reply);
+    }
+
+    /* Let's check what we have inside the list */
+    reply = static_cast<redisReply *>(redisCommand(c,"LRANGE mylist 0 -1"));
+    if (reply->type == REDIS_REPLY_ARRAY) {
+        for (j = 0; j < reply->elements; j++) {
+            printf("%u) %s\n", j, reply->element[j]->str);
+        }
+    }
+    freeReplyObject(reply);
+
+    /* Disconnects and frees the context */
+    redisFree(c);
+
+    return 0;
+}

--- a/hiredis.h
+++ b/hiredis.h
@@ -33,10 +33,16 @@
 
 #ifndef __HIREDIS_H
 #define __HIREDIS_H
-#include "read.h"
+
 #include <stdarg.h> /* for va_list */
-#include <sys/time.h> /* for struct timeval */
 #include <stdint.h> /* uintXX_t, etc */
+#include <sys/time.h> /* for struct timeval */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "read.h"
 #include "sds.h" /* for sds */
 
 #define HIREDIS_MAJOR 0
@@ -102,10 +108,6 @@
             strncat((buf), err_str, ((len) - 1));                              \
         }                                                                      \
     } while (0)
-#endif
-
-#ifdef __cplusplus
-extern "C" {
 #endif
 
 /* This is the reply object returned by redisCommand() */

--- a/sds.c
+++ b/sds.c
@@ -120,6 +120,16 @@ void sdsclear(sds s) {
     sh->buf[0] = '\0';
 }
 
+size_t sdslen(const sds s) {
+    struct sdshdr *sh = (struct sdshdr *)(s-sizeof *sh);
+    return sh->len;
+}
+
+size_t sdsavail(const sds s) {
+    struct sdshdr *sh = (struct sdshdr *)(s-sizeof *sh);
+    return sh->free;
+}
+
 /* Enlarge the free space at the end of the sds string so that the caller
  * is sure that after calling this function can overwrite up to addlen
  * bytes after the end of the string, plus one more byte for nul term.

--- a/sds.h
+++ b/sds.h
@@ -47,16 +47,8 @@ struct sdshdr {
     char buf[];
 };
 
-static inline size_t sdslen(const sds s) {
-    struct sdshdr *sh = (struct sdshdr *)(s-sizeof *sh);
-    return sh->len;
-}
-
-static inline size_t sdsavail(const sds s) {
-    struct sdshdr *sh = (struct sdshdr *)(s-sizeof *sh);
-    return sh->free;
-}
-
+size_t sdslen(const sds s);
+size_t sdsavail(const sds s);
 sds sdsnewlen(const void *init, size_t initlen);
 sds sdsnew(const char *init);
 sds sdsempty(void);


### PR DESCRIPTION
This fixes #364 
Probably static inlining is not a good idea because the compiler is much smarter: 

https://www.kernel.org/doc/Documentation/CodingStyle
Chapter 15: The inline disease

I think because sds actually comes from redis itself it needs to be fixed there and be pulled into hiredis.