### PR TITLE
fix: Rename DEBUG to DEBUG_FLAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ This removes the following old function aliases, use the new name now:
 | redisReplyReaderGetObject   | redisReaderGetObject   |
 | redisReplyReaderGetError    | redisReaderGetError    |
 
+* The `DEBUG` variable in the Makefile was renamed to `DEBUG_FLAGS`
+
+Previously it broke some builds for people that had `DEBUG` set to some arbitrary value,
+due to debugging other software.
+By renaming we avoid unintentional name clashes.
+
+Simply rename `DEBUG` to `DEBUG_FLAGS` in your environment to make it working again.
+
 ### 0.13.3 (2015-09-16)
 
 * Revert "Clear `REDIS_CONNECTED` flag when connection is closed".

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ CC:=$(shell sh -c 'type $(CC) >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 CXX:=$(shell sh -c 'type $(CXX) >/dev/null 2>/dev/null && echo $(CXX) || echo g++')
 OPTIMIZATION?=-O3
 WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings
-DEBUG?= -g -ggdb
-REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG) $(ARCH)
+DEBUG_FLAGS?= -g -ggdb
+REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(ARCH)
 REAL_LDFLAGS=$(LDFLAGS) $(ARCH)
 
 DYLIBSUFFIX=so


### PR DESCRIPTION
This avoids issues with environments where DEBUG is set to an arbitrary
value to force debug mode in other tools.

BREAKING CHANGE: This breaks builds that explicitely set `DEBUG` to
                 some value (even the empty value).
                 To get back the old behaviour change the `DEBUG_FLAGS`
                 variable now.

Cloes #381