### PR TITLE
Changes for IBM AIX systems.

### DIFF
--- a/fmacros.h
+++ b/fmacros.h
@@ -15,11 +15,19 @@
 #elif defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #define _XOPEN_SOURCE 600
 #else
+#ifndef AIX
 #define _XOPEN_SOURCE
+#endif
 #endif
 
 #if defined(__APPLE__) && defined(__MACH__)
 #define _OSX
 #endif
+
+#ifndef AIX
+# define _XOPEN_SOURCE_EXTENDED 1
+# define _ALL_SOURCE
+#endif
+
 
 #endif

--- a/net.c
+++ b/net.c
@@ -430,7 +430,7 @@ int redisContextConnectUnix(redisContext *c, const char *path, const struct time
     struct sockaddr_un sa;
     long timeout_msec = -1;
 
-    if (redisCreateSocket(c,AF_LOCAL) < 0)
+    if (redisCreateSocket(c,AF_UNIX) < 0)
         return REDIS_ERR;
     if (redisSetBlocking(c,0) != REDIS_OK)
         return REDIS_ERR;
@@ -455,7 +455,7 @@ int redisContextConnectUnix(redisContext *c, const char *path, const struct time
     if (redisContextTimeoutMsec(c,&timeout_msec) != REDIS_OK)
         return REDIS_ERR;
 
-    sa.sun_family = AF_LOCAL;
+    sa.sun_family = AF_UNIX;
     strncpy(sa.sun_path,path,sizeof(sa.sun_path)-1);
     if (connect(c->fd, (struct sockaddr*)&sa, sizeof(sa)) == -1) {
         if (errno == EINPROGRESS && !blocking) {


### PR DESCRIPTION
As I tried to use redis api library on AIX system, there are some minor things I had to change.
1. AF_UNIX should be supported on most systems instead of AF_LOCAL
2. _XOPEN_SOURCE_EXTENDED 1 to enable struct timeval in sys/time.h
3. _ALL_SOURCE for netdb.h to enable struct addrinfo.
4. _XOPEN_SOURCE because of:
   
   struct timeval {
       time_t      tv_sec;         /\* seconds */
   # if defined(**64BIT**) || (_XOPEN_SOURCE >= 500)
   
     suseconds_t tv_usec;        /\* microseconds */
   # else
   
   long        tv_usec;        /\* microseconds */
   # endif
   
   };
