### PR TITLE
Typo format in redisFormatSdsCommandArgv function

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -507,7 +507,7 @@ int redisFormatSdsCommandArgv(sds *target, int argc, const char **argv,
     cmd = sdscatfmt(cmd, "*%i\r\n", argc);
     for (j=0; j < argc; j++) {
         len = argvlen ? argvlen[j] : strlen(argv[j]);
-        cmd = sdscatfmt(cmd, "$%T\r\n", len);
+        cmd = sdscatfmt(cmd, "$%u\r\n", len);
         cmd = sdscatlen(cmd, argv[j], len);
         cmd = sdscatlen(cmd, "\r\n", sizeof("\r\n")-1);
     }


### PR DESCRIPTION
this issue is very significant, because not allow the proper execution of the "function redisCommandArgv". The server returns "invalid bulk length".
Thanks!