### PR TITLE
Fix a compile error for C++

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -79,7 +79,7 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 #define SDS_TYPE_64 4
 #define SDS_TYPE_MASK 7
 #define SDS_TYPE_BITS 3
-#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));
+#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))));
 #define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
 #define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
 


### PR DESCRIPTION
There is a compile error in the file sds.h when using g++. 
error: invalid conversion from ‘void*’ to ...

This issue is fixed by this commit.

Thanks!