### PR TITLE
Fixing compiler warnings

### DIFF
--- a/adapters/libev.h
+++ b/adapters/libev.h
@@ -44,22 +44,24 @@ typedef struct redisLibevEvents {
 } redisLibevEvents;
 
 static void redisLibevReadEvent(EV_P_ ev_io *watcher, int revents) {
+    redisLibevEvents *e;
 #if EV_MULTIPLICITY
     ((void)loop);
 #endif
     ((void)revents);
 
-    redisLibevEvents *e = (redisLibevEvents*)watcher->data;
+    e = (redisLibevEvents*)watcher->data;
     redisAsyncHandleRead(e->context);
 }
 
 static void redisLibevWriteEvent(EV_P_ ev_io *watcher, int revents) {
+    redisLibevEvents *e;
 #if EV_MULTIPLICITY
     ((void)loop);
 #endif
     ((void)revents);
 
-    redisLibevEvents *e = (redisLibevEvents*)watcher->data;
+    e = (redisLibevEvents*)watcher->data;
     redisAsyncHandleWrite(e->context);
 }
 


### PR DESCRIPTION
With some flags enabled, the warnings that all declarations should precede code gets triggered. Fixing it by moving declarations to top of function.