### PR TITLE
Do not define _XOPEN_SOURCE for OS X

### DIFF
--- a/fmacros.h
+++ b/fmacros.h
@@ -13,7 +13,9 @@
 #if defined(__sun__)
 #define _POSIX_C_SOURCE 200112L
 #else
+#if !(defined(__APPLE__) && defined(__MACH__))
 #define _XOPEN_SOURCE 600
+#endif
 #endif
 
 #if defined(__APPLE__) && defined(__MACH__)


### PR DESCRIPTION
redis@bb1747b appears to have introduced a build regression for OS X (and possibly elsewhere, I've only tested on a local Mac environment) — in master right now `make` reliably fails on OS X as reported in redis#431.

There looks to be another PR to fix the issue in redis#433.

This PR here simply returns to the previous behavior on OS X in a minimally-invasive way. There are of course a few different ways to do this with the directives; feel free to do something different, I just care that master can build on OS X 🙇