### PR TITLE
Fully preserve original _XOPEN_SOURCE behavior on OS X

### DIFF
--- a/fmacros.h
+++ b/fmacros.h
@@ -13,7 +13,9 @@
 #if defined(__sun__)
 #define _POSIX_C_SOURCE 200112L
 #else
-#if !(defined(__APPLE__) && defined(__MACH__))
+#if defined(__APPLE__) && defined(__MACH__)
+#define _XOPEN_SOURCE
+#else
 #define _XOPEN_SOURCE 600
 #endif
 #endif


### PR DESCRIPTION
Just to be extra-careful. The original behavior [implied an empty `define` for systems not covered by the directives; OS X in the case we're interested in)](https://github.com/redis/hiredis/blob/74b7495f9308f2c183ff24fa482c5304a444cd90/fmacros.h#L14). Not a big deal, but we can make sure to still keep that around. 🏇 
