### PR TITLE
Counting pending subscribe to unset SUBSCRIBED flag properly in async context.

### DIFF
--- a/async.c
+++ b/async.c
@@ -395,7 +395,7 @@ static int __redisGetSubscribeCallback(redisAsyncContext *ac, redisReply *reply,
                 cb->pending_subs -= 1;
             }
 
-            memcpy(dstcb,dictGetEntryVal(de),sizeof(*dstcb));
+            memcpy(dstcb,cb,sizeof(*dstcb));
 
             /* If this is an unsubscribe message, remove it. */
             if (strcasecmp(stype+pvariant,"unsubscribe") == 0) {

--- a/async.c
+++ b/async.c
@@ -407,7 +407,9 @@ static int __redisGetSubscribeCallback(redisAsyncContext *ac, redisReply *reply,
                 assert(reply->element[2]->type == REDIS_REPLY_INTEGER);
 
                 /* Unset subscribed flag only when no pipelined pending subscribe. */
-                if (reply->element[2]->integer == 0 && dictSize(callbacks) == 0)
+                if (reply->element[2]->integer == 0 
+                    && dictSize(ac->sub.channels) == 0
+                    && dictSize(ac->sub.patterns) == 0)
                     c->flags &= ~REDIS_SUBSCRIBED;
             }
         }

--- a/async.h
+++ b/async.h
@@ -45,6 +45,7 @@ typedef void (redisCallbackFn)(struct redisAsyncContext*, void*, void*);
 typedef struct redisCallback {
     struct redisCallback *next; /* simple singly linked list */
     redisCallbackFn *fn;
+    int pending_subs;
     void *privdata;
 } redisCallback;
 


### PR DESCRIPTION
Issue #396 shows assertion fail on re-subscribing right after unsubscribe command.

It is caused after we unset `REDIS_SUBSCRIBED` flag on unsubscribe reply with 0 subscription, but we still have pending subscribe reply, and assertion fails the context's `REDIS_SUBSCRIBED` flag if off.

To evade this, I introduced a pending subscribe counter to the `struc tredisAsyncCallback` in order to unset the flag in a right time.
