### PR TITLE
Remove trailing comma in redisConnectionType enum

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -133,7 +133,7 @@ void redisFreeSdsCommand(sds cmd);
 
 enum redisConnectionType {
     REDIS_CONN_TCP,
-    REDIS_CONN_UNIX,
+    REDIS_CONN_UNIX
 };
 
 /* Context for a connection to Redis */


### PR DESCRIPTION
Remove trailing comma in last value of `redisConnectionType` enum. This causes a compiler warning on Solaris compilers. I'd like to build this on Solaris with `-Werror`. However, due to the trailing comma, I cannot do that.

This PR removes the trailing comma, which should prevent it causing compiler warnings on any architecture.