### PR TITLE
Fix __redisSetErrorFromErrno() can not get error string.

### DIFF
--- a/net.c
+++ b/net.c
@@ -65,12 +65,13 @@ static void redisContextCloseFd(redisContext *c) {
 }
 
 static void __redisSetErrorFromErrno(redisContext *c, int type, const char *prefix) {
+    int errorno = errno;  /* snprintf() may change errno */
     char buf[128] = { 0 };
     size_t len = 0;
 
     if (prefix != NULL)
         len = snprintf(buf,sizeof(buf),"%s: ",prefix);
-    __redis_strerror_r(errno, (char *)(buf + len), sizeof(buf) - len);
+    __redis_strerror_r(errorno, (char *)(buf + len), sizeof(buf) - len);
     __redisSetError(c,type,buf);
 }
 


### PR DESCRIPTION
snprintf() may change errno.