### PR TITLE
redisLibeventCleanup will be leak

### DIFF
--- a/adapters/libevent.h
+++ b/adapters/libevent.h
@@ -73,8 +73,8 @@ static void redisLibeventDelWrite(void *privdata) {
 
 static void redisLibeventCleanup(void *privdata) {
     redisLibeventEvents *e = (redisLibeventEvents*)privdata;
-    event_del(e->rev);
-    event_del(e->wev);
+    event_free(e->rev);
+    event_free(e->wev);
     free(e);
 }
 


### PR DESCRIPTION
event_del can not free the "e->rev" and "e->wev",that will leak when reconnect the redis