### PR TITLE
Fix compilation on FreeBSD 10.3 with default compiler

### DIFF
--- a/fmacros.h
+++ b/fmacros.h
@@ -13,7 +13,7 @@
 #if defined(__sun__)
 #define _POSIX_C_SOURCE 200112L
 #else
-#if !(defined(__APPLE__) && defined(__MACH__))
+#if !(defined(__APPLE__) && defined(__MACH__)) && !(defined(__FreeBSD__))
 #define _XOPEN_SOURCE 600
 #endif
 #endif


### PR DESCRIPTION
Given FreeBSD 10.3 with default compiler:

> $ cc -v
> FreeBSD clang version 3.4.1 (tags/RELEASE_34/dot1-final 208032) 20140512
> Target: x86_64-unknown-freebsd10.3

Defining _XOPEN_SOURCE to 600 on the fixed line leads to the following errors:

> cc -std=c99 -pedantic -c -O3 -fPIC  -Wall -W -Wstrict-prototypes -Wwrite-strings -g -ggdb  net.c
> net.c:435:29: error: use of undeclared identifier 'AF_LOCAL'
>     if (redisCreateSocket(c,AF_LOCAL) < 0)
>                             ^
> net.c:460:21: error: use of undeclared identifier 'AF_LOCAL'
>     sa.sun_family = AF_LOCAL;
>                     ^
> 2 errors generated.
> 

AF_LOCAL is defined in sys/socket.h within ifdef __BSD_VISIBLE.

__BSD_VISIBLE could be defined in sys/cdefs.h, but it is never done if _XOPEN_SOURCE is defined.

So on FreeBSD _XOPEN_SOURCE shouldn't be defined.