### PR TITLE
calloc param fixes and NULL check

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -710,6 +710,8 @@ redisContext *redisConnectNonBlock(const char *ip, int port) {
 redisContext *redisConnectBindNonBlock(const char *ip, int port,
                                        const char *source_addr) {
     redisContext *c = redisContextInit();
+	if (c == NULL)
+        return NULL;
     c->flags &= ~REDIS_BLOCK;
     redisContextConnectBindTcp(c,ip,port,NULL,source_addr);
     return c;
@@ -718,6 +720,8 @@ redisContext *redisConnectBindNonBlock(const char *ip, int port,
 redisContext *redisConnectBindNonBlockWithReuse(const char *ip, int port,
                                                 const char *source_addr) {
     redisContext *c = redisContextInit();
+	if (c == NULL)
+        return NULL;
     c->flags &= ~REDIS_BLOCK;
     c->flags |= REDIS_REUSEADDR;
     redisContextConnectBindTcp(c,ip,port,NULL,source_addr);

--- a/read.c
+++ b/read.c
@@ -416,7 +416,7 @@ static int processItem(redisReader *r) {
 redisReader *redisReaderCreateWithFunctions(redisReplyObjectFunctions *fn) {
     redisReader *r;
 
-    r = calloc(sizeof(redisReader),1);
+    r = calloc(1,sizeof(redisReader));
     if (r == NULL)
         return NULL;
 


### PR DESCRIPTION
1、The calloc function prototype is void *calloc(size_t nmemb, size_t size)， 
Correct call is calloc(1,sizeof(redisReader));

2、redisContext *c = redisContextInit() maybe return NULL,  check it;