### PR TITLE
Prevent FD leakage when calling fork(2)+exec(2) 

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -724,6 +724,47 @@ redisContext *redisConnectBindNonBlockWithReuse(const char *ip, int port,
     return c;
 }
 
+redisContext *redisConnectCloseOnExec(const char *ip, int port) {
+    redisContext *c;
+
+    c = redisContextInit();
+    if (c == NULL) {
+        return NULL;
+    }
+
+    c->flags |= REDIS_BLOCK;
+    c->flags |= REDIS_CLOEXEC;
+    redisContextConnectTcp(c,ip,port,NULL);
+    return c;
+}
+
+redisContext *redisConnectWithTimeoutCloseOnExec(const char *ip, int port, const struct timeval tv) {
+    redisContext *c;
+
+    c = redisContextInit();
+    if (c == NULL)
+        return NULL;
+
+    c->flags |= REDIS_BLOCK;
+    c->flags |= REDIS_CLOEXEC;
+    redisContextConnectTcp(c,ip,port,&tv);
+    return c;
+}
+
+redisContext *redisConnectNonBlockCloseOnExec(const char *ip, int port) {
+    redisContext *c;
+
+    c = redisContextInit();
+    if (c == NULL)
+        return NULL;
+
+    c->flags &= ~REDIS_BLOCK;
+    c->flags |= REDIS_CLOEXEC;
+    redisContextConnectTcp(c,ip,port,NULL);
+    return c;
+}
+
+
 redisContext *redisConnectUnix(const char *path) {
     redisContext *c;
 

--- a/hiredis.h
+++ b/hiredis.h
@@ -74,6 +74,9 @@
 /* Flag that is set when we should set SO_REUSEADDR before calling bind() */
 #define REDIS_REUSEADDR 0x80
 
+/* Flag that is set when we should set FD_CLOEXEC when opening the socket */
+#define REDIS_CLOEXEC 0x100
+
 #define REDIS_KEEPALIVE_INTERVAL 15 /* seconds */
 
 /* number of times we retry to connect in the case of EADDRNOTAVAIL and
@@ -167,6 +170,9 @@ redisContext *redisConnectBindNonBlock(const char *ip, int port,
                                        const char *source_addr);
 redisContext *redisConnectBindNonBlockWithReuse(const char *ip, int port,
                                                 const char *source_addr);
+redisContext *redisConnectCloseOnExec(const char *ip, int port);
+redisContext *redisConnectWithTimeoutCloseOnExec(const char *ip, int port, const struct timeval tv);
+redisContext *redisConnectNonBlockCloseOnExec(const char *ip, int port);
 redisContext *redisConnectUnix(const char *path);
 redisContext *redisConnectUnixWithTimeout(const char *path, const struct timeval tv);
 redisContext *redisConnectUnixNonBlock(const char *path);

--- a/net.c
+++ b/net.c
@@ -54,6 +54,14 @@
 #include "net.h"
 #include "sds.h"
 
+#ifdef SOCK_CLOEXEC
+/* sock_cloexec is initialized to SOCK_CLOEXEC and cleared to zero if
+ * a socket() call ever fails with EINVAL. */
+static int sock_cloexec = SOCK_CLOEXEC;
+#else
+#define sock_cloexec 0
+#endif
+
 /* Defined in hiredis.c */
 void __redisSetError(redisContext *c, int type, const char *str);
 
@@ -270,8 +278,10 @@ static int _redisContextConnectTcp(redisContext *c, const char *addr, int port,
     struct addrinfo hints, *servinfo, *bservinfo, *p, *b;
     int blocking = (c->flags & REDIS_BLOCK);
     int reuseaddr = (c->flags & REDIS_REUSEADDR);
+    int set_cloexec = (c->flags & REDIS_CLOEXEC);
     int reuses = 0;
     long timeout_msec = -1;
+    int socket_type;
 
     servinfo = NULL;
     c->connection_type = REDIS_CONN_TCP;
@@ -336,8 +346,39 @@ static int _redisContextConnectTcp(redisContext *c, const char *addr, int port,
     }
     for (p = servinfo; p != NULL; p = p->ai_next) {
 addrretry:
-        if ((s = socket(p->ai_family,p->ai_socktype,p->ai_protocol)) == -1)
+        socket_type = p->ai_socktype;
+        if (set_cloexec) {
+            socket_type |= sock_cloexec;
+        }
+
+        s = socket(p->ai_family, socket_type, p->ai_protocol);
+        /* If we attempted to open the socket with SOCK_CLOEXEC and
+         * errno == EINVAL, that means setting it on socket creation
+         * is not supported. We clear sock_cloexec so it doesn't do
+         * anything the next time we use it, and try to create it
+         * without SOCK_CLOEXEC. */
+        if (s == -1 && (socket_type & sock_cloexec) && errno == EINVAL) {
+            socket_type &= ~sock_cloexec;
+            sock_cloexec = 0;
+            s = socket(p->ai_family, socket_type, p->ai_protocol);
+        }
+
+        if (s == -1)
             continue;
+
+        /* If creating the socket with SOCK_CLOEXEC failed, we need to set
+         * FD_CLOEXEC on it ASAP in order to minimize the possibility that
+         * another thread in the running program will fork and inherit the
+         * file descriptor, so we do this right after checking if the socket
+         * has been created. Note that we're being optmistic here and there's
+         * no guarantees that we will be able to set it in time. */
+        if (set_cloexec && !sock_cloexec) {
+            if (fcntl(s, F_SETFD, FD_CLOEXEC) == -1) {
+                __redisSetErrorFromErrno(c, REDIS_ERR_IO, "fcntl(F_SETFD)");
+                redisContextCloseFd(c);
+                return REDIS_ERR;
+            }
+        }
 
         c->fd = s;
         if (redisSetBlocking(c,0) != REDIS_OK)


### PR DESCRIPTION
I couldn't think of a better way to test this behavior, but I'm open to suggestions.

This should resolve #555.