### PR TITLE
Remove $(ARCH) expansion from the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ endef
 export REDIS_TEST_CONFIG
 
 # Fallback to gcc when $CC is not in $PATH.
-CC:=$(shell sh -c 'type $(CC) >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
-CXX:=$(shell sh -c 'type $(CXX) >/dev/null 2>/dev/null && echo $(CXX) || echo g++')
+CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
+CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || echo g++')
 OPTIMIZATION?=-O3
 WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings
 DEBUG_FLAGS?= -g -ggdb

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ CXX:=$(shell sh -c 'type $(CXX) >/dev/null 2>/dev/null && echo $(CXX) || echo g+
 OPTIMIZATION?=-O3
 WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings
 DEBUG_FLAGS?= -g -ggdb
-REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(ARCH)
-REAL_LDFLAGS=$(LDFLAGS) $(ARCH)
+REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
+REAL_LDFLAGS=$(LDFLAGS)
 
 DYLIBSUFFIX=so
 STLIBSUFFIX=a


### PR DESCRIPTION
Some compilation environments (such as Yocto) define the ARCH
environment variable to indicate the target architecture. For
such enviroments, hiredis build fails, because the expanded
$(ARCH) variable in the Makefile gets erroneously interpreted
as an argument to the `-ggdb' command line option during the
compilation stage or as an input file name during the linking
stage.

This patch removes $(ARCH) expansions from the Makefile. This
doesn't harm cross-compilation, the latter goes fine with the
properly assigned CC environment variable. For native builds,
this patch does not imply any changes.

Signed-off-by: Dmitri Vorobiev <dmitri.vorobiev@movial.com>