### PR TITLE
Make XOPEN_SOURCE definition explicit per architecture

### DIFF
--- a/fmacros.h
+++ b/fmacros.h
@@ -10,12 +10,18 @@
 #include <sys/cdefs.h>
 #endif
 
+#if defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#define _XOPEN_SOURCE 600
+#elif defined(__APPLE__) && defined(__MACH__)
+#define _XOPEN_SOURCE
+#elif defined(__FreeBSD__)
+// intentionally left blank, don't define _XOPEN_SOURCE
+#else
+#define _XOPEN_SOURCE
+#endif
+
 #if defined(__sun__)
 #define _POSIX_C_SOURCE 200112L
-#else
-#if !(defined(__APPLE__) && defined(__MACH__)) && !(defined(__FreeBSD__))
-#define _XOPEN_SOURCE 600
-#endif
 #endif
 
 #if defined(__APPLE__) && defined(__MACH__)


### PR DESCRIPTION
Fixes #441