### PR TITLE
SSL Client support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ STLIBNAME=$(LIBNAME).$(STLIBSUFFIX)
 STLIB_MAKE_CMD=ar rcs $(STLIBNAME)
 
 ifdef USE_SSL
-	OPENSSL_PREFIX=/usr/local/opt/openssl
+	# This is the prefix of openssl on my system. This should be the sane default
+	# based on the platform
+	OPENSSL_PREFIX?=/usr/local/opt/openssl
 	CFLAGS+=-I$(OPENSSL_PREFIX)/include -DHIREDIS_SSL
 	LDFLAGS+=-L$(OPENSSL_PREFIX)/lib -lssl -lcrypto
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # Copyright (C) 2010-2011 Pieter Noordhuis <pcnoordhuis at gmail dot com>
 # This file is released under the BSD license, see the COPYING file
 
-OBJ=net.o hiredis.o sds.o async.o read.o
-EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib
+OBJ=net.o hiredis.o sds.o async.o read.o sslio.o
+EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib hiredis-example-ssl
 TESTS=hiredis-test
 LIBNAME=libhiredis
 PKGCONFNAME=hiredis.pc
@@ -53,6 +53,10 @@ DYLIB_MAKE_CMD=$(CC) -shared -Wl,-soname,$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(L
 STLIBNAME=$(LIBNAME).$(STLIBSUFFIX)
 STLIB_MAKE_CMD=ar rcs $(STLIBNAME)
 
+OPENSSL_PREFIX=/usr/local/opt/openssl
+CFLAGS+=-I$(OPENSSL_PREFIX)/include
+LDFLAGS+=-L$(OPENSSL_PREFIX)/lib -lssl -lcrypto
+
 # Platform-specific overrides
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 ifeq ($(uname_S),SunOS)
@@ -71,10 +75,11 @@ all: $(DYLIBNAME) $(STLIBNAME) hiredis-test $(PKGCONFNAME)
 # Deps (use make dep to generate this)
 async.o: async.c fmacros.h async.h hiredis.h read.h sds.h net.h dict.c dict.h
 dict.o: dict.c fmacros.h dict.h
-hiredis.o: hiredis.c fmacros.h hiredis.h read.h sds.h net.h
+hiredis.o: hiredis.c fmacros.h hiredis.h read.h sds.h net.h sslio.h
 net.o: net.c fmacros.h net.h hiredis.h read.h sds.h
 read.o: read.c fmacros.h read.h sds.h
 sds.o: sds.c sds.h
+sslio.o: sslio.c sslio.h hiredis.h
 test.o: test.c fmacros.h hiredis.h read.h sds.h
 
 $(DYLIBNAME): $(OBJ)
@@ -101,6 +106,9 @@ hiredis-example-ivykis: examples/example-ivykis.c adapters/ivykis.h $(STLIBNAME)
 
 hiredis-example-macosx: examples/example-macosx.c adapters/macosx.h $(STLIBNAME)
 	$(CC) -o examples/$@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I. $< -framework CoreFoundation $(STLIBNAME)
+
+hiredis-example-ssl: examples/example-ssl.c $(STLIBNAME)
+	$(CC) -o examples/$@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I. $< $(STLIBNAME)
 
 ifndef AE_DIR
 hiredis-example-ae:
@@ -159,7 +167,7 @@ clean:
 	rm -rf $(DYLIBNAME) $(STLIBNAME) $(TESTS) $(PKGCONFNAME) examples/hiredis-example* *.o *.gcda *.gcno *.gcov
 
 dep:
-	$(CC) -MM *.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -MM *.c
 
 ifeq ($(uname_S),$(filter $(uname_S),SunOS OpenBSD))
   INSTALL?= cp -r

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # This file is released under the BSD license, see the COPYING file
 
 OBJ=net.o hiredis.o sds.o async.o read.o sslio.o
-EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib hiredis-example-ssl
+EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib \
+		 hiredis-example-ssl hiredis-example-libevent-ssl
 TESTS=hiredis-test
 LIBNAME=libhiredis
 PKGCONFNAME=hiredis.pc
@@ -93,6 +94,9 @@ static: $(STLIBNAME)
 
 # Binaries:
 hiredis-example-libevent: examples/example-libevent.c adapters/libevent.h $(STLIBNAME)
+	$(CC) -o examples/$@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I. $< -levent $(STLIBNAME)
+
+hiredis-example-libevent-ssl: examples/example-libevent-ssl.c adapters/libevent.h $(STLIBNAME)
 	$(CC) -o examples/$@ $(REAL_CFLAGS) $(REAL_LDFLAGS) -I. $< -levent $(STLIBNAME)
 
 hiredis-example-libev: examples/example-libev.c adapters/libev.h $(STLIBNAME)

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,11 @@ DYLIB_MAKE_CMD=$(CC) -shared -Wl,-soname,$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(L
 STLIBNAME=$(LIBNAME).$(STLIBSUFFIX)
 STLIB_MAKE_CMD=ar rcs $(STLIBNAME)
 
-OPENSSL_PREFIX=/usr/local/opt/openssl
-CFLAGS+=-I$(OPENSSL_PREFIX)/include
-LDFLAGS+=-L$(OPENSSL_PREFIX)/lib -lssl -lcrypto
+ifdef USE_SSL
+	OPENSSL_PREFIX=/usr/local/opt/openssl
+	CFLAGS+=-I$(OPENSSL_PREFIX)/include -DHIREDIS_SSL
+	LDFLAGS+=-L$(OPENSSL_PREFIX)/lib -lssl -lcrypto
+endif
 
 # Platform-specific overrides
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || ec
 OPTIMIZATION?=-O3
 WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings
 DEBUG_FLAGS?= -g -ggdb
-REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
+REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) 
 REAL_LDFLAGS=$(LDFLAGS)
 
 DYLIBSUFFIX=so
@@ -53,6 +53,8 @@ DYLIBNAME=$(LIBNAME).$(DYLIBSUFFIX)
 DYLIB_MAKE_CMD=$(CC) -shared -Wl,-soname,$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
 STLIBNAME=$(LIBNAME).$(STLIBSUFFIX)
 STLIB_MAKE_CMD=ar rcs $(STLIBNAME)
+
+USE_SSL:=1
 
 ifdef USE_SSL
 	# This is the prefix of openssl on my system. This should be the sane default

--- a/async.c
+++ b/async.c
@@ -512,10 +512,12 @@ static int __redisAsyncHandleConnect(redisAsyncContext *ac) {
     return REDIS_OK;
 }
 
-#ifndef HIREDIS_NOSSL
 /**
  * Handle SSL when socket becomes available for reading. This also handles
- * read-while-write and write-while-read
+ * read-while-write and write-while-read.
+ * 
+ * These functions will not work properly unless `HIREDIS_SSL` is defined
+ * (however, they will compile)
  */
 static void asyncSslRead(redisAsyncContext *ac) {
     int rv;
@@ -579,19 +581,6 @@ static void asyncSslWrite(redisAsyncContext *ac) {
     /* Always reschedule a read */
     _EL_ADD_READ(ac);
 }
-#else
-
-/* Just so we're able to compile */
-static void asyncSslRead(redisAsyncContext *ac) {
-    abort();
-    (void)ac;
-}
-static void asyncSslWrite(redisAsyncContext *ac) {
-    abort();
-    (void)ac;
-}
-
-#endif
 
 /* This function should be called when the socket is readable.
  * It processes all replies that can be read and executes their callbacks.

--- a/examples/example-libevent-ssl.c
+++ b/examples/example-libevent-ssl.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+
+#include <hiredis.h>
+#include <async.h>
+#include <adapters/libevent.h>
+
+void getCallback(redisAsyncContext *c, void *r, void *privdata) {
+    redisReply *reply = r;
+    if (reply == NULL) return;
+    printf("argv[%s]: %s\n", (char*)privdata, reply->str);
+
+    /* Disconnect after receiving the reply to GET */
+    redisAsyncDisconnect(c);
+}
+
+void connectCallback(const redisAsyncContext *c, int status) {
+    if (status != REDIS_OK) {
+        printf("Error: %s\n", c->errstr);
+        return;
+    }
+    printf("Connected...\n");
+}
+
+void disconnectCallback(const redisAsyncContext *c, int status) {
+    if (status != REDIS_OK) {
+        printf("Error: %s\n", c->errstr);
+        return;
+    }
+    printf("Disconnected...\n");
+}
+
+int main (int argc, char **argv) {
+    signal(SIGPIPE, SIG_IGN);
+    struct event_base *base = event_base_new();
+    if (argc < 5) {
+        fprintf(stderr,
+                "Usage: %s <key> <host> <port> <cert> <certKey> [ca]\n", argv[0]);
+        exit(1);
+    }
+
+    const char *value = argv[1];
+    size_t nvalue = strlen(value);
+
+    const char *hostname = argv[2];
+    int port = atoi(argv[3]);
+
+    const char *cert = argv[4];
+    const char *certKey = argv[5];
+    const char *caCert = argc > 5 ? argv[6] : NULL;
+
+    redisAsyncContext *c = redisAsyncConnect(hostname, port);
+    if (c->err) {
+        /* Let *c leak for now... */
+        printf("Error: %s\n", c->errstr);
+        return 1;
+    }
+    if (redisSecureConnection(&c->c, caCert, cert, certKey) != REDIS_OK) {
+        printf("SSL Error!\n");
+        exit(1);
+    }
+
+    redisLibeventAttach(c,base);
+    redisAsyncSetConnectCallback(c,connectCallback);
+    redisAsyncSetDisconnectCallback(c,disconnectCallback);
+    redisAsyncCommand(c, NULL, NULL, "SET key %b", value, nvalue);
+    redisAsyncCommand(c, getCallback, (char*)"end-1", "GET key");
+    event_base_dispatch(base);
+    return 0;
+}

--- a/examples/example-ssl.c
+++ b/examples/example-ssl.c
@@ -1,0 +1,92 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <hiredis.h>
+
+int main(int argc, char **argv) {
+    unsigned int j;
+    redisContext *c;
+    redisReply *reply;
+    if (argc < 4) {
+        printf("Usage: %s <host> <port> <cert> <key> [ca]\n", argv[0]);
+        exit(1);
+    }
+    const char *hostname = (argc > 1) ? argv[1] : "127.0.0.1";
+    int port = atoi(argv[2]);
+    const char *cert = argv[3];
+    const char *key = argv[4];
+    const char *ca = argc > 4 ? argv[5] : NULL;
+
+    struct timeval timeout = { 1, 500000 }; // 1.5 seconds
+    c = redisConnectWithTimeout(hostname, port, timeout);
+    if (c == NULL || c->err) {
+        if (c) {
+            printf("Connection error: %s\n", c->errstr);
+            redisFree(c);
+        } else {
+            printf("Connection error: can't allocate redis context\n");
+        }
+        exit(1);
+    }
+
+    if (redisSecureConnection(c, ca, cert, key) != REDIS_OK) {
+        printf("Couldn't initialize SSL!\n");
+        printf("Error: %s\n", c->errstr);
+        redisFree(c);
+        exit(1);
+    }
+
+    /* PING server */
+    reply = redisCommand(c,"PING");
+    printf("PING: %s\n", reply->str);
+    freeReplyObject(reply);
+
+    /* Set a key */
+    reply = redisCommand(c,"SET %s %s", "foo", "hello world");
+    printf("SET: %s\n", reply->str);
+    freeReplyObject(reply);
+
+    /* Set a key using binary safe API */
+    reply = redisCommand(c,"SET %b %b", "bar", (size_t) 3, "hello", (size_t) 5);
+    printf("SET (binary API): %s\n", reply->str);
+    freeReplyObject(reply);
+
+    /* Try a GET and two INCR */
+    reply = redisCommand(c,"GET foo");
+    printf("GET foo: %s\n", reply->str);
+    freeReplyObject(reply);
+
+    reply = redisCommand(c,"INCR counter");
+    printf("INCR counter: %lld\n", reply->integer);
+    freeReplyObject(reply);
+    /* again ... */
+    reply = redisCommand(c,"INCR counter");
+    printf("INCR counter: %lld\n", reply->integer);
+    freeReplyObject(reply);
+
+    /* Create a list of numbers, from 0 to 9 */
+    reply = redisCommand(c,"DEL mylist");
+    freeReplyObject(reply);
+    for (j = 0; j < 10; j++) {
+        char buf[64];
+
+        snprintf(buf,64,"%u",j);
+        reply = redisCommand(c,"LPUSH mylist element-%s", buf);
+        freeReplyObject(reply);
+    }
+
+    /* Let's check what we have inside the list */
+    reply = redisCommand(c,"LRANGE mylist 0 -1");
+    if (reply->type == REDIS_REPLY_ARRAY) {
+        for (j = 0; j < reply->elements; j++) {
+            printf("%u) %s\n", j, reply->element[j]->str);
+        }
+    }
+    freeReplyObject(reply);
+
+    /* Disconnects and frees the context */
+    redisFree(c);
+
+    return 0;
+}

--- a/hiredis.c
+++ b/hiredis.c
@@ -42,6 +42,7 @@
 #include "hiredis.h"
 #include "net.h"
 #include "sds.h"
+#include "sslio.h"
 
 static redisReply *createReplyObject(int type);
 static void *createStringObject(const redisReadTask *task, char *str, size_t len);
@@ -630,6 +631,9 @@ void redisFree(redisContext *c) {
         free(c->unix_sock.path);
     if (c->timeout)
         free(c->timeout);
+    if (c->ssl) {
+        redisFreeSsl(c->ssl);
+    }
     free(c);
 }
 
@@ -776,6 +780,11 @@ redisContext *redisConnectFd(int fd) {
     return c;
 }
 
+int redisSecureConnection(redisContext *c, const char *caPath,
+                          const char *certPath, const char *keyPath) {
+    return redisSslCreate(c, caPath, certPath, keyPath);
+}
+
 /* Set read/write timeout on a blocking socket. */
 int redisSetTimeout(redisContext *c, const struct timeval tv) {
     if (c->flags & REDIS_BLOCK)
@@ -788,6 +797,24 @@ int redisEnableKeepAlive(redisContext *c) {
     if (redisKeepAlive(c, REDIS_KEEPALIVE_INTERVAL) != REDIS_OK)
         return REDIS_ERR;
     return REDIS_OK;
+}
+
+static int rawRead(redisContext *c, char *buf, size_t bufcap) {
+    int nread = read(c->fd, buf, bufcap);
+    if (nread == -1) {
+        if ((errno == EAGAIN && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
+            /* Try again later */
+            return 0;
+        } else {
+            __redisSetError(c, REDIS_ERR_IO, NULL);
+            return -1;
+        }
+    } else if (nread == 0) {
+        __redisSetError(c, REDIS_ERR_EOF, "Server closed the connection");
+        return -1;
+    } else {
+        return nread;
+    }
 }
 
 /* Use this function to handle a read event on the descriptor. It will try
@@ -803,24 +830,31 @@ int redisBufferRead(redisContext *c) {
     if (c->err)
         return REDIS_ERR;
 
-    nread = read(c->fd,buf,sizeof(buf));
-    if (nread == -1) {
+    nread = c->flags & REDIS_SSL ?
+        redisSslRead(c, buf, sizeof(buf)) : rawRead(c, buf, sizeof(buf));
+    if (nread > 0) {
+        if (redisReaderFeed(c->reader, buf, nread) != REDIS_OK) {
+            __redisSetError(c, c->reader->err, c->reader->errstr);
+            return REDIS_ERR;
+        } else {
+        }
+    } else if (nread < 0) {
+        return REDIS_ERR;
+    }
+    return REDIS_OK;
+}
+
+static int rawWrite(redisContext *c) {
+    int nwritten = write(c->fd, c->obuf, sdslen(c->obuf));
+    if (nwritten < 0) {
         if ((errno == EAGAIN && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
             /* Try again later */
         } else {
-            __redisSetError(c,REDIS_ERR_IO,NULL);
-            return REDIS_ERR;
-        }
-    } else if (nread == 0) {
-        __redisSetError(c,REDIS_ERR_EOF,"Server closed the connection");
-        return REDIS_ERR;
-    } else {
-        if (redisReaderFeed(c->reader,buf,nread) != REDIS_OK) {
-            __redisSetError(c,c->reader->err,c->reader->errstr);
-            return REDIS_ERR;
+            __redisSetError(c, REDIS_ERR_IO, NULL);
+            return -1;
         }
     }
-    return REDIS_OK;
+    return nwritten;
 }
 
 /* Write the output buffer to the socket.
@@ -833,21 +867,15 @@ int redisBufferRead(redisContext *c) {
  * c->errstr to hold the appropriate error string.
  */
 int redisBufferWrite(redisContext *c, int *done) {
-    int nwritten;
 
     /* Return early when the context has seen an error. */
     if (c->err)
         return REDIS_ERR;
 
     if (sdslen(c->obuf) > 0) {
-        nwritten = write(c->fd,c->obuf,sdslen(c->obuf));
-        if (nwritten == -1) {
-            if ((errno == EAGAIN && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
-                /* Try again later */
-            } else {
-                __redisSetError(c,REDIS_ERR_IO,NULL);
-                return REDIS_ERR;
-            }
+        int nwritten = (c->flags & REDIS_SSL) ? redisSslWrite(c) : rawWrite(c);
+        if (nwritten < 0) {
+            return REDIS_ERR;
         } else if (nwritten > 0) {
             if (nwritten == (signed)sdslen(c->obuf)) {
                 sdsfree(c->obuf);

--- a/hiredis.h
+++ b/hiredis.h
@@ -74,6 +74,9 @@
 /* Flag that is set when we should set SO_REUSEADDR before calling bind() */
 #define REDIS_REUSEADDR 0x80
 
+/* Flag that is set when this connection is done through SSL */
+#define REDIS_SSL 0x100
+
 #define REDIS_KEEPALIVE_INTERVAL 15 /* seconds */
 
 /* number of times we retry to connect in the case of EADDRNOTAVAIL and
@@ -136,6 +139,8 @@ enum redisConnectionType {
     REDIS_CONN_UNIX
 };
 
+struct redisSsl;
+
 /* Context for a connection to Redis */
 typedef struct redisContext {
     int err; /* Error flags, 0 when there is no error */
@@ -158,6 +163,9 @@ typedef struct redisContext {
         char *path;
     } unix_sock;
 
+    /* For SSL communication */
+    struct redisSsl *ssl;
+
 } redisContext;
 
 redisContext *redisConnect(const char *ip, int port);
@@ -171,6 +179,13 @@ redisContext *redisConnectUnix(const char *path);
 redisContext *redisConnectUnixWithTimeout(const char *path, const struct timeval tv);
 redisContext *redisConnectUnixNonBlock(const char *path);
 redisContext *redisConnectFd(int fd);
+
+/**
+ * Secure the connection using SSL. This should be done before any command is
+ * executed on the connection.
+ */
+int redisSecureConnection(redisContext *c, const char *capath, const char *certpath,
+                          const char *keypath);
 
 /**
  * Reconnect the given context using the saved information.

--- a/sslio.c
+++ b/sslio.c
@@ -1,0 +1,197 @@
+#include "hiredis.h"
+#include "sslio.h"
+
+#include <assert.h>
+#ifndef HIREDIS_NOSSL
+#include <pthread.h>
+
+void __redisSetError(redisContext *c, int type, const char *str);
+
+static void sslLogCallback(const SSL *ssl, int where, int ret) {
+    const char *retstr = "";
+    int should_log = 1;
+    /* Ignore low-level SSL stuff */
+
+    if (where & SSL_CB_ALERT) {
+        should_log = 1;
+    }
+    if (where == SSL_CB_HANDSHAKE_START || where == SSL_CB_HANDSHAKE_DONE) {
+        should_log = 1;
+    }
+    if ((where & SSL_CB_EXIT) && ret == 0) {
+        should_log = 1;
+    }
+
+    if (!should_log) {
+        return;
+    }
+
+    retstr = SSL_alert_type_string(ret);
+    printf("ST(0x%x). %s. R(0x%x)%s\n", where, SSL_state_string_long(ssl), ret, retstr);
+
+    if (where == SSL_CB_HANDSHAKE_DONE) {
+        printf("Using SSL version %s. Cipher=%s\n", SSL_get_version(ssl), SSL_get_cipher_name(ssl));
+    }
+}
+
+typedef pthread_mutex_t sslLockType;
+static void sslLockInit(sslLockType *l) {
+    pthread_mutex_init(l, NULL);
+}
+static void sslLockAcquire(sslLockType *l) {
+    pthread_mutex_lock(l);
+}
+static void sslLockRelease(sslLockType *l) {
+    pthread_mutex_unlock(l);
+}
+static pthread_mutex_t *ossl_locks;
+
+static void opensslDoLock(int mode, int lkid, const char *f, int line) {
+    sslLockType *l = ossl_locks + lkid;
+
+    if (mode & CRYPTO_LOCK) {
+        sslLockAcquire(l);
+    } else {
+        sslLockRelease(l);
+    }
+    
+    (void)f;
+    (void)line;
+}
+
+static void initOpensslLocks(void) {
+    unsigned ii, nlocks;
+    if (CRYPTO_get_locking_callback() != NULL) {
+        /* Someone already set the callback before us. Don't destroy it! */
+        return;
+    }
+    nlocks = CRYPTO_num_locks();
+    ossl_locks = malloc(sizeof(*ossl_locks) * nlocks);
+    for (ii = 0; ii < nlocks; ii++) {
+        sslLockInit(ossl_locks + ii);
+    }
+    CRYPTO_set_locking_callback(opensslDoLock);
+}
+
+void redisFreeSsl(redisSsl *ssl){
+    if (ssl->ctx) {
+        SSL_CTX_free(ssl->ctx);
+    }
+    if (ssl->ssl) {
+        SSL_free(ssl->ssl);
+    }
+    free(ssl);
+}
+
+int redisSslCreate(redisContext *c, const char *capath, const char *certpath,
+                   const char *keypath) {
+    assert(!c->ssl);
+    c->ssl = calloc(1, sizeof(*c->ssl));
+    static int isInit = 0;
+    if (!isInit) {
+        isInit = 1;
+        SSL_library_init();
+        initOpensslLocks();
+    }
+
+    redisSsl *s = c->ssl;
+    s->ctx = SSL_CTX_new(SSLv23_client_method());
+    SSL_CTX_set_info_callback(s->ctx, sslLogCallback);
+    SSL_CTX_set_mode(s->ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+    SSL_CTX_set_options(s->ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
+    SSL_CTX_set_verify(s->ctx, SSL_VERIFY_PEER, NULL);
+
+    if ((certpath != NULL && keypath == NULL) || (keypath != NULL && certpath == NULL)) {
+        __redisSetError(c, REDIS_ERR, "certpath and keypath must be specified together");
+        return REDIS_ERR;
+    }
+
+    if (capath) {
+        if (!SSL_CTX_load_verify_locations(s->ctx, capath, NULL)) {
+            __redisSetError(c, REDIS_ERR, "Invalid CA certificate");
+            return REDIS_ERR;
+        }
+    }
+    if (certpath) {
+        if (!SSL_CTX_use_certificate_chain_file(s->ctx, certpath)) {
+            __redisSetError(c, REDIS_ERR, "Invalid client certificate");
+            return REDIS_ERR;
+        }
+        if (!SSL_CTX_use_PrivateKey_file(s->ctx, keypath, SSL_FILETYPE_PEM)) {
+            __redisSetError(c, REDIS_ERR, "Invalid client key");
+            return REDIS_ERR;
+        }
+        printf("Loaded certificate!\n");
+    }
+
+    s->ssl = SSL_new(s->ctx);
+    if (!s->ssl) {
+        __redisSetError(c, REDIS_ERR, "Couldn't create new SSL instance");
+        return REDIS_ERR;
+    }
+
+    SSL_set_fd(s->ssl, c->fd);
+    SSL_set_connect_state(s->ssl);
+
+    c->flags |= REDIS_SSL;
+    printf("Before SSL_connect()\n");
+    int rv = SSL_connect(c->ssl->ssl);
+    if (rv == 1) {
+        printf("SSL_connect() success!\n");
+        return REDIS_OK;
+    }
+    printf("ConnectRV: %d\n", rv);
+
+    rv = SSL_get_error(s->ssl, rv);
+    if (((c->flags & REDIS_BLOCK) == 0) &&
+        (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE)) {
+        return REDIS_OK;
+    }
+
+    if (c->err == 0) {
+        __redisSetError(c, REDIS_ERR_IO, "SSL_connect() failed");
+        printf("rv: %d\n", rv);
+    }
+    printf("ERROR!!!\n");
+    return REDIS_ERR;
+}
+
+int redisSslRead(redisContext *c, char *buf, size_t bufcap) {
+    int nread = SSL_read(c->ssl->ssl, buf, bufcap);
+    if (nread > 0) {
+        return nread;
+    } else if (nread == 0) {
+        __redisSetError(c, REDIS_ERR_EOF, "Server closed the connection");
+        return -1;
+    } else {
+        int err = SSL_get_error(c->ssl->ssl, nread);
+        if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+            return 0;
+        } else {
+            __redisSetError(c, REDIS_ERR_IO, NULL);
+            return -1;
+        }
+    }
+}
+
+int redisSslWrite(redisContext *c) {
+    size_t len = c->ssl->lastLen ? c->ssl->lastLen : sdslen(c->obuf);
+    int rv = SSL_write(c->ssl->ssl, c->obuf, len);
+
+    if (rv > 0) {
+        c->ssl->lastLen = 0;
+    } else if (rv < 0) {
+        c->ssl->lastLen = len;
+
+        int err = SSL_get_error(c->ssl->ssl, rv);
+        if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+            return 0;
+        } else {
+            __redisSetError(c, REDIS_ERR_IO, NULL);
+            return -1;
+        }
+    }
+    return rv;
+}
+
+#endif

--- a/sslio.c
+++ b/sslio.c
@@ -57,7 +57,7 @@ static void opensslDoLock(int mode, int lkid, const char *f, int line) {
     } else {
         sslLockRelease(l);
     }
-    
+
     (void)f;
     (void)line;
 }

--- a/sslio.c
+++ b/sslio.c
@@ -2,7 +2,7 @@
 #include "sslio.h"
 
 #include <assert.h>
-#ifndef HIREDIS_NOSSL
+#ifdef HIREDIS_SSL
 #include <pthread.h>
 
 void __redisSetError(redisContext *c, int type, const char *str);

--- a/sslio.h
+++ b/sslio.h
@@ -2,19 +2,26 @@
 #define REDIS_SSLIO_H
 
 
-#ifdef HIREDIS_NOSSL
+#ifndef HIREDIS_SSL
 typedef struct redisSsl {
-    int dummy;
+    size_t lastLen;
+    int wantRead;
+    int pendingWrite;
 } redisSsl;
-static void redisFreeSsl(redisSsl *) {
+static inline void redisFreeSsl(redisSsl *ssl) {
+    (void)ssl;
 }
-static int redisSslCreate(struct redisContext *c) {
+static inline int redisSslCreate(struct redisContext *c, const char *ca,
+                          const char *cert, const char *key) {
+    (void)c;(void)ca;(void)cert;(void)key;
     return REDIS_ERR;
 }
-static int redisSslRead(struct redisContect *c, char *s, size_t, n) {
+static inline int redisSslRead(struct redisContext *c, char *s, size_t n) {
+    (void)c;(void)s;(void)n;
     return -1;
 }
-static int redisSslWrite(struct redisContext *c) {
+static inline int redisSslWrite(struct redisContext *c) {
+    (void)c;
     return -1;
 }
 #else
@@ -53,5 +60,5 @@ int redisSslCreate(struct redisContext *c, const char *caPath,
 int redisSslRead(struct redisContext *c, char *buf, size_t bufcap);
 int redisSslWrite(struct redisContext *c);
 
-#endif /* !HIREDIS_NOSSL */
+#endif /* HIREDIS_SSL */
 #endif /* HIREDIS_SSLIO_H */

--- a/sslio.h
+++ b/sslio.h
@@ -1,0 +1,48 @@
+#ifndef REDIS_SSLIO_H
+#define REDIS_SSLIO_H
+
+
+#ifdef HIREDIS_NOSSL
+typedef struct redisSsl {
+    int dummy;
+} redisSsl;
+static void redisFreeSsl(redisSsl *) {
+}
+static int redisSslCreate(struct redisContext *c) {
+    return REDIS_ERR;
+}
+static int redisSslRead(struct redisContect *c, char *s, size_t, n) {
+    return -1;
+}
+static int redisSslWrite(struct redisContext *c) {
+    return -1;
+}
+#else
+#include <openssl/ssl.h>
+
+/**
+ * This file contains routines for HIREDIS' SSL
+ */
+
+typedef struct redisSsl {
+    SSL *ssl;
+    SSL_CTX *ctx;
+
+    /**
+     * SSL_write() requires to be called again with the same arguments it was
+     * previously called with in the event of an SSL_read/SSL_write situation
+     */
+    size_t lastLen;
+} redisSsl;
+
+struct redisContext;
+
+void redisFreeSsl(redisSsl *);
+int redisSslCreate(struct redisContext *c, const char *caPath,
+                   const char *certPath, const char *keyPath);
+
+int redisSslRead(struct redisContext *c, char *buf, size_t bufcap);
+int redisSslWrite(struct redisContext *c);
+
+#endif /* !HIREDIS_NOSSL */
+#endif /* HIREDIS_SSLIO_H */

--- a/sslio.h
+++ b/sslio.h
@@ -33,6 +33,15 @@ typedef struct redisSsl {
      * previously called with in the event of an SSL_read/SSL_write situation
      */
     size_t lastLen;
+
+    /** Whether the SSL layer requires read (possibly before a write) */
+    int wantRead;
+
+    /**
+     * Whether a write was requested prior to a read. If set, the write()
+     * should resume whenever a read takes place, if possible
+     */
+    int pendingWrite;
 } redisSsl;
 
 struct redisContext;


### PR DESCRIPTION
This provides SSL client support for communicating with an SSL-secured Redis implementation. The user-facing API is exposed as bolted-on, which makes modifying existing applications easier. This works in my basic testing so far.

The SSL implementation assumes mutual TLS auth. SSL support is disabled by default at compilation. To use SSL, set `USE_SSL` in the build environment.

```
$make USE_SSL=1
```

This should enable the `HIREDIS_SSL` preprocessor define, which should enable the SSL bits. Note that you may want to also adjust your `OPENSSL_PREFIX` build variable to your desired openssl installation. This is probably only a concern for OSX where there are typically both Homebrew and Apple variants provided. On linux there should only be a single version found in `/usr/lib/` or similar. The default value is `/opt/local/openssl`.

Once the library is built, you should be able to call

```
int redisSecureConnection(redisContext *c, const char *capath, const char *certpath,
                          const char *keypath);
```

On the connection. This will perform openssl negotiation. The reason I didn't provide another variant of `redisConnect` is twofold. (1) I wanted other applications to be able to simply add (rather than change) their existing connection code - so this also works via fd etc. (2) Users can quickly debug if an error is coming from the connection layer or openssl layer.

I've also added examples (the sync example and the libev and libevent examples).