### PR TITLE
hiredis.h : Fix the return type of redisCommand(s)

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -212,9 +212,9 @@ int redisAppendCommandArgv(redisContext *c, int argc, const char **argv, const s
  * NULL if there was an error in performing the request, otherwise it will
  * return the reply. In a non-blocking context, it is identical to calling
  * only redisAppendCommand and will always return NULL. */
-void *redisvCommand(redisContext *c, const char *format, va_list ap);
-void *redisCommand(redisContext *c, const char *format, ...);
-void *redisCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen);
+redisReply *redisvCommand(redisContext *c, const char *format, va_list ap);
+redisReply *redisCommand(redisContext *c, const char *format, ...);
+redisReply *redisCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
hiredis.h : the wrong void type of redisCommand(s) changed to the redisReply type.