### PR TITLE
fix common realloc mistake and add null check more

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -219,7 +219,10 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
     hdrlen = sdsHdrSize(type);
     if (oldtype==type) {
         newsh = s_realloc(sh, hdrlen+newlen+1);
-        if (newsh == NULL) return NULL;
+        if (newsh == NULL) {
+            s_free(sh);
+            return NULL;
+        }
         s = (char*)newsh+hdrlen;
     } else {
         /* Since the header size changes, need to move the string forward,
@@ -592,6 +595,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
         /* Make sure there is always space for at least 1 char. */
         if (sdsavail(s)==0) {
             s = sdsMakeRoomFor(s,1);
+            if (s == NULL) goto fmt_error;
         }
 
         switch(*f) {
@@ -605,6 +609,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
                 l = (next == 's') ? strlen(str) : sdslen(str);
                 if (sdsavail(s) < l) {
                     s = sdsMakeRoomFor(s,l);
+                    if (s == NULL) goto fmt_error;
                 }
                 memcpy(s+i,str,l);
                 sdsinclen(s,l);
@@ -621,6 +626,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
                     l = sdsll2str(buf,num);
                     if (sdsavail(s) < l) {
                         s = sdsMakeRoomFor(s,l);
+                        if (s == NULL) goto fmt_error;
                     }
                     memcpy(s+i,buf,l);
                     sdsinclen(s,l);
@@ -638,6 +644,7 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
                     l = sdsull2str(buf,unum);
                     if (sdsavail(s) < l) {
                         s = sdsMakeRoomFor(s,l);
+                        if (s == NULL) goto fmt_error;
                     }
                     memcpy(s+i,buf,l);
                     sdsinclen(s,l);
@@ -662,6 +669,10 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
     /* Add null-term */
     s[i] = '\0';
     return s;
+
+fmt_error:
+    va_end(ap);
+    return NULL;
 }
 
 /* Remove the part of the string from left and from right composed just of
@@ -1018,10 +1029,18 @@ sds *sdssplitargs(const char *line, int *argc) {
                 if (*p) p++;
             }
             /* add the token to the vector */
-            vector = s_realloc(vector,((*argc)+1)*sizeof(char*));
-            vector[*argc] = current;
-            (*argc)++;
-            current = NULL;
+            {
+                char **new_vector = s_realloc(vector,((*argc)+1)*sizeof(char*));
+                if (new_vector == NULL) {
+                    s_free(vector);
+                    return NULL;
+                }
+                
+                vector = new_vector;
+                vector[*argc] = current;
+                (*argc)++;
+                current = NULL;
+            }
         } else {
             /* Even on empty input string return something not NULL. */
             if (vector == NULL) vector = s_malloc(sizeof(void*));


### PR DESCRIPTION
1] hiredis is client library, so need more null check and memory lick check.
 because using null ptr can destroy application.

2] I refered https://www.mantidproject.org/How_to_fix_CppCheck_Errors for realloc issue.
