### PR TITLE
Fix some POSIX usage issues

### DIFF
--- a/fmacros.h
+++ b/fmacros.h
@@ -1,38 +1,12 @@
 #ifndef __HIREDIS_FMACRO_H
 #define __HIREDIS_FMACRO_H
 
-#if defined(__linux__)
-#define _BSD_SOURCE
-#define _DEFAULT_SOURCE
-#endif
-
-#if defined(__CYGWIN__)
-#include <sys/cdefs.h>
-#endif
-
-#if defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #define _XOPEN_SOURCE 600
-#elif defined(__APPLE__) && defined(__MACH__)
-#define _XOPEN_SOURCE
-#elif defined(__FreeBSD__)
-// intentionally left blank, don't define _XOPEN_SOURCE
-#elif defined(AIX)
-// intentionally left blank, don't define _XOPEN_SOURCE
-#else
-#define _XOPEN_SOURCE
-#endif
-
-#if defined(__sun__)
 #define _POSIX_C_SOURCE 200112L
-#endif
 
 #if defined(__APPLE__) && defined(__MACH__)
-#define _OSX
-#endif
-
-#ifndef AIX
-# define _XOPEN_SOURCE_EXTENDED 1
-# define _ALL_SOURCE
+/* Enable TCP_KEEPALIVE */
+#define _DARWIN_C_SOURCE
 #endif
 
 #endif

--- a/hiredis.c
+++ b/hiredis.c
@@ -596,14 +596,8 @@ static redisContext *redisContextInit(void) {
     if (c == NULL)
         return NULL;
 
-    c->err = 0;
-    c->errstr[0] = '\0';
     c->obuf = sdsempty();
     c->reader = redisReaderCreate();
-    c->tcp.host = NULL;
-    c->tcp.source_addr = NULL;
-    c->unix_sock.path = NULL;
-    c->timeout = NULL;
 
     if (c->obuf == NULL || c->reader == NULL) {
         redisFree(c);

--- a/hiredis.c
+++ b/hiredis.c
@@ -84,16 +84,14 @@ void freeReplyObject(void *reply) {
     case REDIS_REPLY_ARRAY:
         if (r->element != NULL) {
             for (j = 0; j < r->elements; j++)
-                if (r->element[j] != NULL)
-                    freeReplyObject(r->element[j]);
+                freeReplyObject(r->element[j]);
             free(r->element);
         }
         break;
     case REDIS_REPLY_ERROR:
     case REDIS_REPLY_STATUS:
     case REDIS_REPLY_STRING:
-        if (r->str != NULL)
-            free(r->str);
+        free(r->str);
         break;
     }
     free(r);
@@ -432,11 +430,7 @@ cleanup:
     }
 
     sdsfree(curarg);
-
-    /* No need to check cmd since it is the last statement that can fail,
-     * but do it anyway to be as defensive as possible. */
-    if (cmd != NULL)
-        free(cmd);
+    free(cmd);
 
     return error_type;
 }
@@ -612,18 +606,12 @@ void redisFree(redisContext *c) {
         return;
     if (c->fd > 0)
         close(c->fd);
-    if (c->obuf != NULL)
-        sdsfree(c->obuf);
-    if (c->reader != NULL)
-        redisReaderFree(c->reader);
-    if (c->tcp.host)
-        free(c->tcp.host);
-    if (c->tcp.source_addr)
-        free(c->tcp.source_addr);
-    if (c->unix_sock.path)
-        free(c->unix_sock.path);
-    if (c->timeout)
-        free(c->timeout);
+    sdsfree(c->obuf);
+    redisReaderFree(c->reader);
+    free(c->tcp.host);
+    free(c->tcp.source_addr);
+    free(c->unix_sock.path);
+    free(c->timeout);
     free(c);
 }
 

--- a/hiredis.c
+++ b/hiredis.c
@@ -581,7 +581,7 @@ void __redisSetError(redisContext *c, int type, const char *str) {
     } else {
         /* Only REDIS_ERR_IO may lack a description! */
         assert(type == REDIS_ERR_IO);
-        __redis_strerror_r(errno, c->errstr, sizeof(c->errstr));
+        strerror_r(errno, c->errstr, sizeof(c->errstr));
     }
 }
 

--- a/hiredis.h
+++ b/hiredis.h
@@ -80,30 +80,6 @@
  * SO_REUSEADDR is being used. */
 #define REDIS_CONNECT_RETRIES  10
 
-/* strerror_r has two completely different prototypes and behaviors
- * depending on system issues, so we need to operate on the error buffer
- * differently depending on which strerror_r we're using. */
-#ifndef _GNU_SOURCE
-/* "regular" POSIX strerror_r that does the right thing. */
-#define __redis_strerror_r(errno, buf, len)                                    \
-    do {                                                                       \
-        strerror_r((errno), (buf), (len));                                     \
-    } while (0)
-#else
-/* "bad" GNU strerror_r we need to clean up after. */
-#define __redis_strerror_r(errno, buf, len)                                    \
-    do {                                                                       \
-        char *err_str = strerror_r((errno), (buf), (len));                     \
-        /* If return value _isn't_ the start of the buffer we passed in,       \
-         * then GNU strerror_r returned an internal static buffer and we       \
-         * need to copy the result into our private buffer. */                 \
-        if (err_str != (buf)) {                                                \
-            strncpy((buf), err_str, ((len) - 1));                              \
-            (buf)[(len)-1] = '\0';                                               \
-        }                                                                      \
-    } while (0)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/net.c
+++ b/net.c
@@ -412,7 +412,10 @@ addrretry:
 error:
     rv = REDIS_ERR;
 end:
-    freeaddrinfo(servinfo);
+    if(servinfo) {
+        freeaddrinfo(servinfo);
+    }
+
     return rv;  // Need to return REDIS_OK if alright
 }
 

--- a/net.c
+++ b/net.c
@@ -285,8 +285,7 @@ static int _redisContextConnectTcp(redisContext *c, const char *addr, int port,
      * This is a bit ugly, but atleast it works and doesn't leak memory.
      **/
     if (c->tcp.host != addr) {
-        if (c->tcp.host)
-            free(c->tcp.host);
+        free(c->tcp.host);
 
         c->tcp.host = strdup(addr);
     }
@@ -299,8 +298,7 @@ static int _redisContextConnectTcp(redisContext *c, const char *addr, int port,
             memcpy(c->timeout, timeout, sizeof(struct timeval));
         }
     } else {
-        if (c->timeout)
-            free(c->timeout);
+        free(c->timeout);
         c->timeout = NULL;
     }
 
@@ -452,8 +450,7 @@ int redisContextConnectUnix(redisContext *c, const char *path, const struct time
             memcpy(c->timeout, timeout, sizeof(struct timeval));
         }
     } else {
-        if (c->timeout)
-            free(c->timeout);
+        free(c->timeout);
         c->timeout = NULL;
     }
 

--- a/net.c
+++ b/net.c
@@ -136,7 +136,7 @@ int redisKeepAlive(redisContext *c, int interval) {
 
     val = interval;
 
-#ifdef _OSX
+#if defined(__APPLE__) && defined(__MACH__)
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &val, sizeof(val)) < 0) {
         __redisSetError(c,REDIS_ERR_OTHER,strerror(errno));
         return REDIS_ERR;

--- a/net.c
+++ b/net.c
@@ -71,7 +71,7 @@ static void __redisSetErrorFromErrno(redisContext *c, int type, const char *pref
 
     if (prefix != NULL)
         len = snprintf(buf,sizeof(buf),"%s: ",prefix);
-    __redis_strerror_r(errorno, (char *)(buf + len), sizeof(buf) - len);
+    strerror_r(errorno, (char *)(buf + len), sizeof(buf) - len);
     __redisSetError(c,type,buf);
 }
 

--- a/net.c
+++ b/net.c
@@ -432,7 +432,7 @@ int redisContextConnectUnix(redisContext *c, const char *path, const struct time
     struct sockaddr_un sa;
     long timeout_msec = -1;
 
-    if (redisCreateSocket(c,AF_LOCAL) < 0)
+    if (redisCreateSocket(c,AF_UNIX) < 0)
         return REDIS_ERR;
     if (redisSetBlocking(c,0) != REDIS_OK)
         return REDIS_ERR;
@@ -457,7 +457,7 @@ int redisContextConnectUnix(redisContext *c, const char *path, const struct time
     if (redisContextTimeoutMsec(c,&timeout_msec) != REDIS_OK)
         return REDIS_ERR;
 
-    sa.sun_family = AF_LOCAL;
+    sa.sun_family = AF_UNIX;
     strncpy(sa.sun_path,path,sizeof(sa.sun_path)-1);
     if (connect(c->fd, (struct sockaddr*)&sa, sizeof(sa)) == -1) {
         if (errno == EINPROGRESS && !blocking) {

--- a/net.h
+++ b/net.h
@@ -37,10 +37,6 @@
 
 #include "hiredis.h"
 
-#if defined(__sun) || defined(AIX)
-#define AF_LOCAL AF_UNIX
-#endif
-
 int redisCheckSocketError(redisContext *c);
 int redisContextSetTimeout(redisContext *c, const struct timeval tv);
 int redisContextConnectTcp(redisContext *c, const char *addr, int port, const struct timeval *timeout);

--- a/read.c
+++ b/read.c
@@ -52,11 +52,9 @@ static void __redisReaderSetError(redisReader *r, int type, const char *str) {
     }
 
     /* Clear input buffer on errors. */
-    if (r->buf != NULL) {
-        sdsfree(r->buf);
-        r->buf = NULL;
-        r->pos = r->len = 0;
-    }
+    sdsfree(r->buf);
+    r->buf = NULL;
+    r->pos = r->len = 0;
 
     /* Reset task stack. */
     r->ridx = -1;
@@ -433,10 +431,11 @@ redisReader *redisReaderCreateWithFunctions(redisReplyObjectFunctions *fn) {
 }
 
 void redisReaderFree(redisReader *r) {
+    if (r == NULL)
+        return;
     if (r->reply != NULL && r->fn && r->fn->freeObject)
         r->fn->freeObject(r->reply);
-    if (r->buf != NULL)
-        sdsfree(r->buf);
+    sdsfree(r->buf);
     free(r);
 }
 

--- a/read.c
+++ b/read.c
@@ -420,8 +420,6 @@ redisReader *redisReaderCreateWithFunctions(redisReplyObjectFunctions *fn) {
     if (r == NULL)
         return NULL;
 
-    r->err = 0;
-    r->errstr[0] = '\0';
     r->fn = fn;
     r->buf = sdsempty();
     r->maxbuf = REDIS_READER_MAX_BUF;


### PR DESCRIPTION
Here's a set of patches fixing some POSIX usage issues. Looking at the history, there's been a lot of issues compiling on other platforms. The root of those problems is AF_LOCAL, the old name for the standardized AF_UNIX. Every platform seems to have their own nuances on whether to define AF_LOCAL. Replacing it with AF_UNIX, and stripping fmacros.h down to just set the two basic version macros fixes all but Darwin, which needs one extra just for TCP_KEEPALIVE.

In glibc, if _XOPEN_SOURCE or _POSIX_C_SOURCE are defined, features.h will not define _GNU_SOURCE, so only the standard version of strerror_r is exposed. __redis_strerror_r is dropped in favor of using the standard version directly. A check could be added to fmacros.h to produce an error if _GNU_SOURCE is defined, but the build will fail in either case.

Some redundancies involving calloc and free are also fixed. calloc is guaranteed to provide a zero-initialized buffer, so initializing fields to zero is redundant. free and various *free functions in hiredis are NULL-safe, so checking before calling them is redundant.

POSIX does not specify the behavior of freeaddrinfo(NULL). In glibc, it's a NOP, but on the BSDs it crashes, so a NULL-check is necessary. d4b715f0aa97bae7bf2f6ebfe4837f39c0451e84 added a code path that can call freeaddrinfo(NULL). The necessary check is added.

In addition to the automatic CI, this was also tested on FreeBSD, OpenBSD, and NetBSD. I don't have AIX or Solaris to test on, so I can't check those.