### PR TITLE
Use absolute install_name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
 ifeq ($(uname_S),Darwin)
   DYLIBSUFFIX=dylib
   DYLIB_MINOR_NAME=$(LIBNAME).$(HIREDIS_SONAME).$(DYLIBSUFFIX)
-  DYLIB_MAKE_CMD=$(CC) -shared -Wl,-install_name,$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
+  DYLIB_MAKE_CMD=$(CC) -shared -Wl,-install_name,$(PREFIX)/$(LIBRARY_PATH)$(DYLIB_MINOR_NAME) -o $(DYLIBNAME) $(LDFLAGS)
 endif
 
 all: $(DYLIBNAME) $(STLIBNAME) hiredis-test $(PKGCONFNAME)


### PR DESCRIPTION
The `install_name` on macOS must be an absolute path (or must use `@executable_path`, `@loader_path` or `@rpath`, but that's less common).

Fixes #437.