### PR TITLE
Use cp -pPR instead of cp -a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 ifeq ($(uname_S),SunOS)
   REAL_LDFLAGS+= -ldl -lnsl -lsocket
   DYLIB_MAKE_CMD=$(CC) -G -o $(DYLIBNAME) -h $(DYLIB_MINOR_NAME) $(LDFLAGS)
-  INSTALL= cp -r
 endif
 ifeq ($(uname_S),Darwin)
   DYLIBSUFFIX=dylib
@@ -161,11 +160,7 @@ clean:
 dep:
 	$(CC) -MM *.c
 
-ifeq ($(uname_S),$(filter $(uname_S),SunOS OpenBSD))
-  INSTALL?= cp -r
-endif
-
-INSTALL?= cp -a
+INSTALL?= cp -pPR
 
 $(PKGCONFNAME): hiredis.h
 	@echo "Generating $@ for pkgconfig..."


### PR DESCRIPTION
`cp` does not support the `-a` flag on all operating systems, such as Mac OS X Leopard 10.5.x or earlier, resulting in:

```
cp: illegal option -- a
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-pvX] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-pvX] source_file ... target_directory
make: *** [install] Error 64
```

From `man cp` on macOS Sierra 10.12.6, `cp -a` is exactly the same as `cp -pPR`, so use that instead.

From `man cp` on macOS Sierra:

> Historic versions of the `cp` utility had a `-r` option. This implementation supports that option; however, its use is strongly discouraged, as it does not correctly copy special files, symbolic links, or fifo's.

So don't ever use that.
