### PR TITLE
Update createArray to take size_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 User code should compare this to `size_t` values as well.
 If it was used to compare to other values, casting might be necessary or can be removed, if casting was applied before.
 
+* `redisReplyObjectFunctions.createArray` now takes `size_t` for its length parameter.
+
 * Remove backwards compatibility macro's
 
 This removes the following old function aliases, use the new name now:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Import latest upstream sds. This breaks applications that are linked against the old hiredis v0.13
 * Fix warnings, when compiled with -Wshadow
 * Make hiredis compile in Cygwin on Windows, now CI-tested
+* Bulk and multi-bulk lengths less than -1 or greater than `LLONG_MAX` are now
+  protocol errors. This is consistent with the RESP specification. On 32-bit
+  platforms, the upper bound is lowered to `SIZE_MAX`.
 
 **BREAKING CHANGES**:
 

--- a/hiredis.c
+++ b/hiredis.c
@@ -45,7 +45,7 @@
 
 static redisReply *createReplyObject(int type);
 static void *createStringObject(const redisReadTask *task, char *str, size_t len);
-static void *createArrayObject(const redisReadTask *task, int elements);
+static void *createArrayObject(const redisReadTask *task, size_t elements);
 static void *createIntegerObject(const redisReadTask *task, long long value);
 static void *createNilObject(const redisReadTask *task);
 
@@ -129,7 +129,7 @@ static void *createStringObject(const redisReadTask *task, char *str, size_t len
     return r;
 }
 
-static void *createArrayObject(const redisReadTask *task, int elements) {
+static void *createArrayObject(const redisReadTask *task, size_t elements) {
     redisReply *r, *parent;
 
     r = createReplyObject(REDIS_REPLY_ARRAY);

--- a/read.c
+++ b/read.c
@@ -385,7 +385,7 @@ static int processMultiBulkItem(redisReader *r) {
 
         root = (r->ridx == 0);
 
-        if (elements < -1 || elements > INT_MAX) {
+        if (elements < -1 || (LLONG_MAX > SIZE_MAX && elements > SIZE_MAX)) {
             __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
                     "Multi-bulk length out of range");
             return REDIS_ERR;

--- a/read.h
+++ b/read.h
@@ -71,7 +71,7 @@ typedef struct redisReadTask {
 
 typedef struct redisReplyObjectFunctions {
     void *(*createString)(const redisReadTask*, char*, size_t);
-    void *(*createArray)(const redisReadTask*, int);
+    void *(*createArray)(const redisReadTask*, size_t);
     void *(*createInteger)(const redisReadTask*, long long);
     void *(*createNil)(const redisReadTask*);
     void (*freeObject)(void*);

--- a/test.c
+++ b/test.c
@@ -358,7 +358,8 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
-    test("Set error when array > INT_MAX: ");
+#if LLONG_MAX > SIZE_MAX
+    test("Set error when array > SIZE_MAX: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, "*9223372036854775807\r\n+asdf\r\n",29);
     ret = redisReaderGetReply(reader,&reply);
@@ -367,7 +368,6 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
-#if LLONG_MAX > SIZE_MAX
     test("Set error when bulk > SIZE_MAX: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, "$9223372036854775807\r\nasdf\r\n",28);


### PR DESCRIPTION
This makes createArray consistent with createString, which also takes size_t. Bounds-check and unit tests are updated to allow up to `min(SIZE_MAX,LLONG_MAX)`. Changelog is updated to mention this API break.

Also included is a missed Changelog entry mentioning the integer parsing changes.