### PR TITLE
Make socket non-blocking before connect()

### DIFF
--- a/net.c
+++ b/net.c
@@ -373,6 +373,10 @@ addrretry:
                 goto error;
             }
         }
+        if (blocking && redisSetBlocking(c,1) != REDIS_OK)
+            goto error;
+        if (redisSetTcpNoDelay(c) != REDIS_OK)
+            goto error;
         if (connect(s,p->ai_addr,p->ai_addrlen) == -1) {
             if (errno == EHOSTUNREACH) {
                 redisContextCloseFd(c);
@@ -391,10 +395,6 @@ addrretry:
                     goto error;
             }
         }
-        if (blocking && redisSetBlocking(c,1) != REDIS_OK)
-            goto error;
-        if (redisSetTcpNoDelay(c) != REDIS_OK)
-            goto error;
 
         c->flags |= REDIS_CONNECTED;
         rv = REDIS_OK;


### PR DESCRIPTION
    Otherwise, in the case of error, socket may become invalid
    and when performing setNonblock() we will get an incorrect error,
    i.e. "setsockopt(TCP_NODELAY): Invalid argument"
    instead of "Connection refused"