### PR TITLE
Make string2ll static to avoid conflict with redis

### DIFF
--- a/read.c
+++ b/read.c
@@ -154,7 +154,7 @@ static char *seekNewline(char *s, size_t len) {
  * Because of its strictness, it is safe to use this function to check if
  * you can convert a string into a long long, and obtain back the string
  * from the number without any loss in the string representation. */
-int string2ll(const char *s, size_t slen, long long *value) {
+static int string2ll(const char *s, size_t slen, long long *value) {
     const char *p = s;
     size_t plen = 0;
     int negative = 0;


### PR DESCRIPTION
See discussion on #609. This should also make it easier for redis to
update the vendored/bundled hiredis (though not by much).