### PR TITLE
Prepare for the 0.14.0 release

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -40,9 +40,9 @@
 #include "sds.h" /* for sds */
 
 #define HIREDIS_MAJOR 0
-#define HIREDIS_MINOR 13
-#define HIREDIS_PATCH 3
-#define HIREDIS_SONAME 0.13
+#define HIREDIS_MINOR 14
+#define HIREDIS_PATCH 0
+#define HIREDIS_SONAME 0.14
 
 /* Connection type can be blocking or non-blocking and is set in the
  * least significant bit of the flags field in redisContext. */


### PR DESCRIPTION
SONAME bumped to 0.14 because we've broken ABI compatibility with 0.13.x