### PR TITLE
Add CPPFLAGS to REAL_CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || ec
 OPTIMIZATION?=-O3
 WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings
 DEBUG_FLAGS?= -g -ggdb
-REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
+REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
 REAL_LDFLAGS=$(LDFLAGS)
 
 DYLIBSUFFIX=so


### PR DESCRIPTION
Noticed this was missing while putting together the new Debian package, where certain hardening flags were added to CPPFLAGS (but not CFLAGS) & were lost by the Makefile.

I'm working around this downstream so no big deal, just wanted to get this PR up before I forget about it.