### PR TITLE
Fix redisBufferRead documentation

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -777,7 +777,7 @@ int redisEnableKeepAlive(redisContext *c) {
 /* Use this function to handle a read event on the descriptor. It will try
  * and read some bytes from the socket and feed them to the reply parser.
  *
- * After this function is called, you may use redisContextReadReply to
+ * After this function is called, you may use redisGetReplyFromReader to
  * see if there is a reply available. */
 int redisBufferRead(redisContext *c) {
     char buf[1024*16];


### PR DESCRIPTION
Stumbled over a small documentation issue while browsing the code. The redisBufferRead comment referred to redisContextReadReply which I cannot find in this codebase nor the old redis-tools one. Presumably this meant to say redisGetReplyFromReader which is how redisBufferRead is used in hiredis.c. Could've also meant the interface function redisReaderGetReply.