### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ return `REDIS_ERR`. The function to set the disconnect callback has the followin
 ```c
 int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn);
 ```
+`ac->data` may be used to pass user data to this callback, the same can be done for redisConnectCallback.
 ### Sending commands and their callbacks
 
 In an asynchronous context, commands are automatically pipelined due to the nature of an event loop.


### PR DESCRIPTION
Adds a note about using context->data to pass user data to connect and disconnect callbacks.

I came across #44, facing the same issue of requiring something in the disconnect callback. Since there will be no `void *privdata` parameter like with other callbacks, a note in the README seems helpful.