### PR TITLE
Enhanced error-handling (OOM) and more (redisAsync* family)

### DIFF
--- a/async.h
+++ b/async.h
@@ -128,8 +128,13 @@ void redisAsyncHandleTimeout(redisAsyncContext *ac);
 void redisAsyncRead(redisAsyncContext *ac);
 void redisAsyncWrite(redisAsyncContext *ac);
 
-/* Command functions for an async context. Write the command to the
- * output buffer and register the provided callback. */
+/* Append functions for an async context. Write the command to the output buffer and register the provided callback. */
+int redisvAsyncAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, va_list ap);
+int redisAsyncAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...);
+int redisAsyncAppendArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, int argc, const char **argv, const size_t *argvlen);
+int redisAsyncFormattedAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *cmd, size_t len);
+
+/* Command functions for an async context. Append the command and trigger WRITE-EVENT */
 int redisvAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, va_list ap);
 int redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...);
 int redisAsyncCommandArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, int argc, const char **argv, const size_t *argvlen);

--- a/dict.c
+++ b/dict.c
@@ -50,7 +50,7 @@ static int _dictInit(dict *ht, dictType *type, void *privDataPtr);
 
 /* Generic hash function (a popular one from Bernstein).
  * I tested a few and this was the best. */
-static unsigned int dictGenHashFunction(const unsigned char *buf, int len) {
+static unsigned int dictGenHashFunction(const unsigned char *buf, size_t len) {
     unsigned int hash = 5381;
 
     while (len--)

--- a/dict.h
+++ b/dict.h
@@ -111,7 +111,7 @@ typedef struct dictIterator {
 #define dictSize(ht) ((ht)->used)
 
 /* API */
-static unsigned int dictGenHashFunction(const unsigned char *buf, int len);
+static unsigned int dictGenHashFunction(const unsigned char *buf, size_t len);
 static dict *dictCreate(dictType *type, void *privDataPtr);
 static int dictExpand(dict *ht, unsigned long size);
 static int dictAdd(dict *ht, void *key, void *val);

--- a/hiredis.c
+++ b/hiredis.c
@@ -638,15 +638,15 @@ void redisFreeCommand(char *cmd) {
     free(cmd);
 }
 
-void __redisSetError(redisContext *c, int type, const char *format, ...) {
-    va_list args;
+void __redisSetError(redisContext *c, int type, const char *str) {
+    size_t len;
 
     c->err = type;
-    if (format != NULL) {
-        va_start(args, format);
-        /* We ignore return value since SetError has no return code */
-        (void) vsnprintf(c->errstr, sizeof(c->errstr), format, args);
-        va_end(args);
+    if (str != NULL) {
+        len = strlen(str);
+        len = len < (sizeof(c->errstr)-1) ? len : (sizeof(c->errstr)-1);
+        memcpy(c->errstr,str,len);
+        c->errstr[len] = '\0';
     } else {
         /* Only REDIS_ERR_IO may lack a description! */
         assert(type == REDIS_ERR_IO);

--- a/hiredis.c
+++ b/hiredis.c
@@ -638,15 +638,15 @@ void redisFreeCommand(char *cmd) {
     free(cmd);
 }
 
-void __redisSetError(redisContext *c, int type, const char *str) {
-    size_t len;
+void __redisSetError(redisContext *c, int type, const char *format, ...) {
+    va_list args;
 
     c->err = type;
-    if (str != NULL) {
-        len = strlen(str);
-        len = len < (sizeof(c->errstr)-1) ? len : (sizeof(c->errstr)-1);
-        memcpy(c->errstr,str,len);
-        c->errstr[len] = '\0';
+    if (format != NULL) {
+        va_start(args, format);
+        /* We ignore return value since SetError has no return code */
+        (void) vsnprintf(c->errstr, sizeof(c->errstr), format, args);
+        va_end(args);
     } else {
         /* Only REDIS_ERR_IO may lack a description! */
         assert(type == REDIS_ERR_IO);


### PR DESCRIPTION
Hiredis: Advanced async-handling

+ hiredis.c: Convert redisSetError to take format and va_args
+ dict.*   : Fixed generic hash function -> cannot really take signed number
+ async.*  : Valdup function now handles OOM properly
             KeyCompare function uses proper sized integers
             nextArgument - change to use proper str-int conversion function
             Added redisAsyncAppend* function family to support buffer
                                                 optimizations in async-mode
             Added proper error handling on OOM errors [inc buffer rollback]