### PR TITLE
Setup .pc file to allow use for cross-compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,8 @@ $(PKGCONFNAME): hiredis.h
 	@echo "Generating $@ for pkgconfig..."
 	@echo prefix=$(PREFIX) > $@
 	@echo exec_prefix=\$${prefix} >> $@
-	@echo libdir=$(PREFIX)/$(LIBRARY_PATH) >> $@
-	@echo includedir=$(PREFIX)/$(INCLUDE_PATH) >> $@
+	@echo libdir=\$${exec_prefix}/$(LIBRARY_PATH) >> $@
+	@echo includedir=\$${prefix}/$(INCLUDE_PATH) >> $@
 	@echo >> $@
 	@echo Name: hiredis >> $@
 	@echo Description: Minimalistic C client library for Redis. >> $@


### PR DESCRIPTION
The Makefile is currently creating the pkg-config file using static lib
and include dir statements. Change that so that projects that
cross-compile hiredis can use pkg-config to setup other programs
depending on it.

Note: these projects (like OpenWrt) call pkg-config with arguments to
overwrite some variables in the .pc file, namely:

--define-variable=prefix=<...>
--define-variable=exec_prefix=<...>

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>