### PR TITLE
Fix Invalid argument after redisAsyncConnectUnix

### DIFF
--- a/net.c
+++ b/net.c
@@ -500,6 +500,7 @@ int redisContextConnectUnix(redisContext *c, const char *path, const struct time
         return REDIS_ERR;
 
     sa = (struct sockaddr_un*)(c->saddr = malloc(sizeof(struct sockaddr_un)));
+    c->addrlen = sizeof(struct sockaddr_un);
     sa->sun_family = AF_UNIX;
     strncpy(sa->sun_path,path,sizeof(sa->sun_path)-1);
     if (connect(c->fd, (struct sockaddr*)sa, sizeof(*sa)) == -1) {


### PR DESCRIPTION
related code:

```
int redisCheckConnectDone(redisContext *c, int *completed) {
    int rc = connect(c->fd, (const struct sockaddr *)c->saddr, c->addrlen);
```