### PR TITLE
The setsockopt and getsockopt API diffs from BSD socket and WSA one

### DIFF
--- a/sockcompat.c
+++ b/sockcompat.c
@@ -197,7 +197,7 @@ int win32_getsockopt(SOCKET sockfd, int level, int optname, void *optval, sockle
             socklen_t dwlen = 0;
             ret = getsockopt(sockfd, level, optname, (char *)&timeout, &dwlen);
             tv->tv_sec = timeout / 1000;
-            tv->tv_usec = timeout * 1000;
+            tv->tv_usec = (timeout * 1000) % 1000000;
         } else {
             ret = WSAEFAULT;
         }

--- a/sockcompat.c
+++ b/sockcompat.c
@@ -192,7 +192,7 @@ int win32_getsockopt(SOCKET sockfd, int level, int optname, void *optval, sockle
     int ret = 0;
     if ((level == SOL_SOCKET) && ((optname == SO_RCVTIMEO) || (optname == SO_SNDTIMEO))) {
         if (*optlen >= sizeof (struct timeval)) {
-            struct timeval *tv = (struct timeval *)optval;
+            struct timeval *tv = optval;
             DWORD timeout = 0;
             socklen_t dwlen = 0;
             ret = getsockopt(sockfd, level, optname, (char *)&timeout, &dwlen);
@@ -212,7 +212,7 @@ int win32_getsockopt(SOCKET sockfd, int level, int optname, void *optval, sockle
 int win32_setsockopt(SOCKET sockfd, int level, int optname, const void *optval, socklen_t optlen) {
     int ret = 0;
     if ((level == SOL_SOCKET) && ((optname == SO_RCVTIMEO) || (optname == SO_SNDTIMEO))) {
-        struct timeval *tv = (struct timeval *)optval;
+        struct timeval *tv = optval;
         DWORD timeout = tv->tv_sec * 1000 + tv->tv_usec / 1000;
         ret = setsockopt(sockfd, level, optname, (const char*)&timeout, sizeof(DWORD));
     } else {

--- a/sockcompat.c
+++ b/sockcompat.c
@@ -192,9 +192,8 @@ int win32_getsockopt(SOCKET sockfd, int level, int optname, void *optval, sockle
     int ret = 0;
     if ((level == SOL_SOCKET) && ((optname == SO_RCVTIMEO) || (optname == SO_SNDTIMEO))) {
         struct timeval *tv = (struct timeval *)optval;
-        DWORD timeout = 0;
-        socklen_t dwlen = 0;
-        ret = getsockopt(sockfd, level, optname, (char *)timeout, &dwlen);
+        DWORD timeout = 0; socklen_t dwlen = 0;
+        ret = getsockopt(sockfd, level, optname, (char *)&timeout, &dwlen);
         tv->tv_sec = timeout / 1000;
         tv->tv_usec = timeout * 1000;
         *optlen = sizeof (struct timeval);


### PR DESCRIPTION
The optval of `SO_RCVTIMEO` and `SO_SNDTIMEO` is a pointer to `DWORD`, not a pointer to `struct timeval` in Windows SDK.

ref:
* [getsockopt on MSDN](https://docs.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-getsockopt)
* [setsockopt on MSDN](https://docs.microsoft.com/en-us/windows/desktop/api/winsock/nf-winsock-setsockopt)