### PR TITLE
Windows: MinGW fixes and Windows Travis builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,3 +73,19 @@ matrix:
         - mkdir build && cd build
         - CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_WITH_INSTALL_RPATH=on
         - ninja -v
+
+    # Windows MSVC 2017
+    - os: windows
+      compiler: msvc
+      env:
+        - MATRIX_EVAL="CC=cl.exe && CXX=cl.exe"
+      before_install:
+        - eval "${MATRIX_EVAL}"
+      install:
+        - choco install ninja
+      script:
+        - mkdir build && cd build
+        - cmd.exe /C '"C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" amd64 &&
+          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release &&
+          ninja -v'
+        - ctest -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,20 @@ script:
   - cmake .. ${EXTRA_CMAKE_OPTS}
   - make VERBOSE=1
   - ctest -V
+
+matrix:
+  include:
+    # Windows MinGW cross compile on Linux
+    - os: linux
+      dist: xenial
+      compiler: mingw
+      addons:
+        apt:
+          packages:
+            - ninja-build
+            - gcc-mingw-w64-x86-64
+            - g++-mingw-w64-x86-64
+      script:
+        - mkdir build && cd build
+        - CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_BUILD_WITH_INSTALL_RPATH=on
+        - ninja -v

--- a/async.c
+++ b/async.c
@@ -32,11 +32,8 @@
 #include "fmacros.h"
 #include <stdlib.h>
 #include <string.h>
-#ifndef _WIN32
+#ifndef _MSC_VER
 #include <strings.h>
-#else
-#define strcasecmp stricmp
-#define strncasecmp  strnicmp
 #endif
 #include <assert.h>
 #include <ctype.h>
@@ -46,6 +43,7 @@
 #include "dict.c"
 #include "sds.h"
 #include "sslio.h"
+#include "win32.h"
 
 #define _EL_ADD_READ(ctx)                                         \
     do {                                                          \

--- a/hiredis.h
+++ b/hiredis.h
@@ -35,10 +35,10 @@
 #define __HIREDIS_H
 #include "read.h"
 #include <stdarg.h> /* for va_list */
-#ifndef _WIN32
+#ifndef _MSC_VER
 #include <sys/time.h> /* for struct timeval */
 #else
-#include <winsock2.h>
+struct timeval; /* forward declaration */
 #endif
 #include <stdint.h> /* uintXX_t, etc */
 #include "sds.h" /* for sds */

--- a/sds.h
+++ b/sds.h
@@ -34,7 +34,7 @@
 #define __SDS_H
 
 #define SDS_MAX_PREALLOC (1024*1024)
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define __attribute__(x)
 #endif
 

--- a/sds.h
+++ b/sds.h
@@ -135,20 +135,20 @@ static inline void sdssetlen(sds s, size_t newlen) {
         case SDS_TYPE_5:
             {
                 unsigned char *fp = ((unsigned char*)s)-1;
-                *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
+                *fp = (unsigned char)(SDS_TYPE_5 | (newlen << SDS_TYPE_BITS));
             }
             break;
         case SDS_TYPE_8:
-            SDS_HDR(8,s)->len = newlen;
+            SDS_HDR(8,s)->len = (uint8_t)newlen;
             break;
         case SDS_TYPE_16:
-            SDS_HDR(16,s)->len = newlen;
+            SDS_HDR(16,s)->len = (uint16_t)newlen;
             break;
         case SDS_TYPE_32:
-            SDS_HDR(32,s)->len = newlen;
+            SDS_HDR(32,s)->len = (uint32_t)newlen;
             break;
         case SDS_TYPE_64:
-            SDS_HDR(64,s)->len = newlen;
+            SDS_HDR(64,s)->len = (uint64_t)newlen;
             break;
     }
 }
@@ -159,21 +159,21 @@ static inline void sdsinclen(sds s, size_t inc) {
         case SDS_TYPE_5:
             {
                 unsigned char *fp = ((unsigned char*)s)-1;
-                unsigned char newlen = SDS_TYPE_5_LEN(flags)+inc;
+                unsigned char newlen = SDS_TYPE_5_LEN(flags)+(unsigned char)inc;
                 *fp = SDS_TYPE_5 | (newlen << SDS_TYPE_BITS);
             }
             break;
         case SDS_TYPE_8:
-            SDS_HDR(8,s)->len += inc;
+            SDS_HDR(8,s)->len += (uint8_t)inc;
             break;
         case SDS_TYPE_16:
-            SDS_HDR(16,s)->len += inc;
+            SDS_HDR(16,s)->len += (uint16_t)inc;
             break;
         case SDS_TYPE_32:
-            SDS_HDR(32,s)->len += inc;
+            SDS_HDR(32,s)->len += (uint32_t)inc;
             break;
         case SDS_TYPE_64:
-            SDS_HDR(64,s)->len += inc;
+            SDS_HDR(64,s)->len += (uint64_t)inc;
             break;
     }
 }
@@ -203,16 +203,16 @@ static inline void sdssetalloc(sds s, size_t newlen) {
             /* Nothing to do, this type has no total allocation info. */
             break;
         case SDS_TYPE_8:
-            SDS_HDR(8,s)->alloc = newlen;
+            SDS_HDR(8,s)->alloc = (uint8_t)newlen;
             break;
         case SDS_TYPE_16:
-            SDS_HDR(16,s)->alloc = newlen;
+            SDS_HDR(16,s)->alloc = (uint16_t)newlen;
             break;
         case SDS_TYPE_32:
-            SDS_HDR(32,s)->alloc = newlen;
+            SDS_HDR(32,s)->alloc = (uint32_t)newlen;
             break;
         case SDS_TYPE_64:
-            SDS_HDR(64,s)->alloc = newlen;
+            SDS_HDR(64,s)->alloc = (uint64_t)newlen;
             break;
     }
 }

--- a/sockcompat.h
+++ b/sockcompat.h
@@ -50,7 +50,9 @@
 #include <ws2tcpip.h>
 #include <stddef.h>
 
+#ifdef _MSC_VER
 typedef signed long ssize_t;
+#endif
 
 /* Emulate the parts of the BSD socket API that we need (override the winsock signatures). */
 int win32_getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res);

--- a/win32.h
+++ b/win32.h
@@ -2,8 +2,18 @@
 #define _WIN32_HELPER_INCLUDE
 #ifdef _MSC_VER
 
+#include <winsock2.h> /* for struct timeval */
+
 #ifndef inline
 #define inline __inline
+#endif
+
+#ifndef strcasecmp
+#define strcasecmp stricmp
+#endif
+
+#ifndef strncasecmp
+#define strncasecmp strnicmp
 #endif
 
 #ifndef va_copy


### PR DESCRIPTION
Unfortunately the MSVC fixes in #658 broke MinGW builds (mainly due to using `_WIN32` instead of `_MSC_VER` when checking if the compiler is MS Visual Studio).

The ifdef-logic has been cleaned up slightly to support both MSVC and MinGW (and possibly Clang etc too).

In addition, a couple of Travis build steps are added that should catch future breakage of the MinGW and MSVC support.