### PR TITLE
redisReaderGetReply leak memory

### DIFF
--- a/read.c
+++ b/read.c
@@ -590,8 +590,11 @@ int redisReaderGetReply(redisReader *r, void **reply) {
 
     /* Emit a reply when there is one. */
     if (r->ridx == -1) {
-        if (reply != NULL)
+        if (reply != NULL) {
             *reply = r->reply;
+        } else if (r->reply != NULL && r->fn && r->fn->freeObject) {
+            r->fn->freeObject(r->reply);
+        }
         r->reply = NULL;
     }
     return REDIS_OK;


### PR DESCRIPTION
I think when the parameter `reply` is NULL, then only set r->reply to NULL at the tail of function will lead to memory leak, so I add some code to call freeObject to free r->reply under some conditions of course.