### PR TITLE
Support changing SSL Mode

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -760,7 +760,12 @@ redisContext *redisConnectFd(redisFD fd) {
 
 int redisSecureConnection(redisContext *c, const char *caPath,
                           const char *certPath, const char *keyPath, const char *servername) {
-    return redisSslCreate(c, caPath, certPath, keyPath, servername);
+    return redisSslCreate(c, caPath, certPath, keyPath, servername, HIREDIS_SSL_VERIFY_PEER);
+}
+
+int redisSecureConnectionWithOptions(redisContext *c, const char *caPath,
+                          const char *certPath, const char *keyPath, const char *servername, int sslOptions) {
+    return redisSslCreate(c, caPath, certPath, keyPath, servername, sslOptions);
 }
 
 /* Set read/write timeout on a blocking socket. */

--- a/hiredis.h
+++ b/hiredis.h
@@ -235,11 +235,24 @@ redisContext *redisConnectUnixNonBlock(const char *path);
 redisContext *redisConnectFd(redisFD fd);
 
 /**
+ *  Redis SSL options
+ */
+# define HIREDIS_SSL_VERIFY_NONE 0x00
+# define HIREDIS_SSL_VERIFY_PEER 0x01
+
+/**
  * Secure the connection using SSL. This should be done before any command is
  * executed on the connection.
  */
 int redisSecureConnection(redisContext *c, const char *capath, const char *certpath,
                           const char *keypath, const char *servername);
+
+/**
+ * Secure the connection using SSL with options. This should be done before any command is
+ * executed on the connection.
+ */
+int redisSecureConnectionWithOptions(redisContext *c, const char *capath, const char *certpath,
+                          const char *keypath, const char *servername, int ssloptions);
 
 /**
  * Reconnect the given context using the saved information.

--- a/sslio.c
+++ b/sslio.c
@@ -88,7 +88,7 @@ void redisFreeSsl(redisSsl *ssl){
 }
 
 int redisSslCreate(redisContext *c, const char *capath, const char *certpath,
-                   const char *keypath, const char *servername) {
+                   const char *keypath, const char *servername, int ssloptions) {
     assert(!c->ssl);
     c->ssl = calloc(1, sizeof(*c->ssl));
     static int isInit = 0;
@@ -103,7 +103,7 @@ int redisSslCreate(redisContext *c, const char *capath, const char *certpath,
     SSL_CTX_set_info_callback(s->ctx, sslLogCallback);
     SSL_CTX_set_mode(s->ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
     SSL_CTX_set_options(s->ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
-    SSL_CTX_set_verify(s->ctx, SSL_VERIFY_PEER, NULL);
+    SSL_CTX_set_verify(s->ctx, ssloptions, NULL);
 
     if ((certpath != NULL && keypath == NULL) || (keypath != NULL && certpath == NULL)) {
         __redisSetError(c, REDIS_ERR, "certpath and keypath must be specified together");

--- a/sslio.h
+++ b/sslio.h
@@ -12,8 +12,8 @@ static inline void redisFreeSsl(redisSsl *ssl) {
     (void)ssl;
 }
 static inline int redisSslCreate(struct redisContext *c, const char *ca,
-                          const char *cert, const char *key, const char *servername) {
-    (void)c;(void)ca;(void)cert;(void)key;(void)servername;
+                          const char *cert, const char *key, const char *servername, int sslOptions) {
+    (void)c;(void)ca;(void)cert;(void)key;(void)servername;(void)sslOptions;
     return REDIS_ERR;
 }
 static inline int redisSslRead(struct redisContext *c, char *s, size_t n) {
@@ -55,7 +55,7 @@ struct redisContext;
 
 void redisFreeSsl(redisSsl *);
 int redisSslCreate(struct redisContext *c, const char *caPath,
-                   const char *certPath, const char *keyPath, const char *servername);
+                   const char *certPath, const char *keyPath, const char *servername, int sslOptions);
 
 int redisSslRead(struct redisContext *c, char *buf, size_t bufcap);
 int redisSslWrite(struct redisContext *c);


### PR DESCRIPTION
- Hiredis SSL default mode is SSL_VERIFY_PEER, which requires a valid certification.
- Amazon ElasticCache (and some servers) doesn't require a certification because the client is a trusted source. So it would be great if Hiredis support an ability to change the SSL mode in the redisSecureConnection.
- It's also a good thing, we should clarify the SSL mode before making the connection.

Original issue: https://github.com/redis/hiredis/issues/646