### PR TITLE
Fixes leaks in unit tests

### DIFF
--- a/test.c
+++ b/test.c
@@ -269,14 +269,14 @@ static void test_format_commands(void) {
 
     sds sds_cmd;
 
-    sds_cmd = sdsempty();
+    sds_cmd = NULL;
     test("Format command into sds by passing argc/argv without lengths: ");
     len = redisFormatSdsCommandArgv(&sds_cmd,argc,argv,NULL);
     test_cond(strncmp(sds_cmd,"*3\r\n$3\r\nSET\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",len) == 0 &&
         len == 4+4+(3+2)+4+(3+2)+4+(3+2));
     sdsfree(sds_cmd);
 
-    sds_cmd = sdsempty();
+    sds_cmd = NULL;
     test("Format command into sds by passing argc/argv with lengths: ");
     len = redisFormatSdsCommandArgv(&sds_cmd,argc,argv,lens);
     test_cond(strncmp(sds_cmd,"*3\r\n$3\r\nSET\r\n$7\r\nfoo\0xxx\r\n$3\r\nbar\r\n",len) == 0 &&


### PR DESCRIPTION
redisFormatSdsCommandArgv takes an sds* and calls sdsempty() for us.

Addresses #714