### PR TITLE
Async context should always call onDisconnect.

### DIFF
--- a/async.c
+++ b/async.c
@@ -290,7 +290,7 @@ static void __redisAsyncFree(redisAsyncContext *ac) {
 
     /* Execute disconnect callback. When redisAsyncFree() initiated destroying
      * this context, the status will always be REDIS_OK. */
-    if (ac->onDisconnect && (c->flags & REDIS_CONNECTED)) {
+    if (ac->onDisconnect) {
         if (c->flags & REDIS_FREEING) {
             ac->onDisconnect(ac,REDIS_OK);
         } else {


### PR DESCRIPTION
There are two cases when client may loose control over the context: when timeout happened and when connection closed just after opening.
In both cases client stays uninformed about what was happened. At least this may lead to memory leak.