### PR TITLE
Fix dead code in sslLogCallback relating to should_log variable.

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -82,8 +82,8 @@ redisContextFuncs redisContextSSLFuncs;
  * Callback used for debugging
  */
 static void sslLogCallback(const SSL *ssl, int where, int ret) {
-    const char *retstr = "";
-    int should_log = 1;
+    const char *retstr;
+    int should_log = 0;
     /* Ignore low-level SSL stuff */
 
     if (where & SSL_CB_ALERT) {


### PR DESCRIPTION
Coverity scans found that the should_log logic in sslLogCallback
is not working as expected because the variable is not correctly
initialised (the conditional code before logging always sets the
value to 1, which it already is).