### PR TITLE
Free the reply in redisGetReply when passed NULL

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -945,8 +945,13 @@ int redisGetReply(redisContext *c, void **reply) {
         } while (aux == NULL);
     }
 
-    /* Set reply object */
-    if (reply != NULL) *reply = aux;
+    /* Set reply or free it if we were passed NULL */
+    if (reply != NULL) {
+        *reply = aux;
+    } else {
+        freeReplyObject(aux);
+    }
+
     return REDIS_OK;
 }
 

--- a/test.c
+++ b/test.c
@@ -591,6 +591,11 @@ static void test_blocking_connection(struct config config) {
               strcasecmp(reply->element[1]->str,"pong") == 0);
     freeReplyObject(reply);
 
+    /* Make sure passing NULL to redisGetReply is safe */
+    test("Can pass NULL to redisGetReply: ");
+    assert(redisAppendCommand(c, "PING") == REDIS_OK);
+    test_cond(redisGetReply(c, NULL) == REDIS_OK);
+
     disconnect(c, 0);
 }
 


### PR DESCRIPTION
We currently perform a NULL check in redisGetReply and don't push the
reply back to the caller, but we don't free any reply meaning that this
will leak memory:

redisGetReply(context, NULL);

This change simply frees the reply if we were passed NULL.

Addresses #740