### PR TITLE
install alloc.h when using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ CONFIGURE_FILE(hiredis.pc.in hiredis.pc @ONLY)
 INSTALL(TARGETS hiredis
     DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
-INSTALL(FILES hiredis.h read.h sds.h async.h
+INSTALL(FILES hiredis.h read.h sds.h async.h alloc.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hiredis)
     
 INSTALL(DIRECTORY adapters


### PR DESCRIPTION
Similar to #756, but for cmake build
note: alloc.h added in #754