### PR TITLE
Provides an optional cleanup callback for async data.

### DIFF
--- a/async.c
+++ b/async.c
@@ -109,6 +109,7 @@ static redisAsyncContext *redisAsyncInitialize(redisContext *c) {
     ac->err = 0;
     ac->errstr = NULL;
     ac->data = NULL;
+    ac->dataCleanup = NULL;
 
     ac->ev.data = NULL;
     ac->ev.addRead = NULL;
@@ -297,6 +298,10 @@ static void __redisAsyncFree(redisAsyncContext *ac) {
         } else {
             ac->onDisconnect(ac,(ac->err == 0) ? REDIS_OK : REDIS_ERR);
         }
+    }
+
+    if (ac->dataCleanup) {
+        ac->dataCleanup(ac->data);
     }
 
     /* Cleanup self */

--- a/async.h
+++ b/async.h
@@ -70,6 +70,7 @@ typedef struct redisAsyncContext {
 
     /* Not used by hiredis */
     void *data;
+    void (*dataCleanup)(void *privdata);
 
     /* Event library data and hooks */
     struct {


### PR DESCRIPTION
This change adds a cleanup event to the redisAsyncContext such that the private data can be deleted or modified as a result of the context being free'd. This way it is possible to allocate private data on the context whose lifetime is tied to that of the context.

This is essentially the only meaningful change to hiredis made by hiredis-vip to support cluster. Adding the data cleanup event to hiredis proper allows for hiredis-vip to be a pure wrapper class that depends on hiredis directly. This way hiredis-vip won't continually lag behind.