### PR TITLE
Use correct libuv call on Windows

### DIFF
--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -106,7 +106,7 @@ static int redisLibuvAttach(redisAsyncContext* ac, uv_loop_t* loop) {
 
   memset(p, 0, sizeof(*p));
 
-  if (uv_poll_init(loop, &p->handle, c->fd) != 0) {
+  if (uv_poll_init_socket(loop, &p->handle, c->fd) != 0) {
     return REDIS_ERR;
   }
 

--- a/net.c
+++ b/net.c
@@ -474,9 +474,6 @@ addrretry:
         }
         if (blocking && redisSetBlocking(c,1) != REDIS_OK)
             goto error;
-#ifdef _MSC_VER
-        _sleep(0);
-#endif
         if (redisSetTcpNoDelay(c) != REDIS_OK)
             goto error;
 

--- a/net.c
+++ b/net.c
@@ -474,6 +474,9 @@ addrretry:
         }
         if (blocking && redisSetBlocking(c,1) != REDIS_OK)
             goto error;
+#ifdef _MSC_VER
+        _sleep(0);
+#endif
         if (redisSetTcpNoDelay(c) != REDIS_OK)
             goto error;
 


### PR DESCRIPTION
Use `uv_poll_init_socket` as this has a slightly different meaning on Windows.  

In Linux the function is equivalent to `uv_poll_init`.