### PR TITLE
Fix USE_SSL=1 make/cmake on OSX and CMake tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ branches:
     - /^release\/.*$/
 
 before_script:
-    - if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew update; brew install redis; fi
+    - if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew update; brew install redis openssl; fi
 
 addons:
   apt:
@@ -27,6 +27,8 @@ addons:
     - libc6-dbg:i386
     - gcc-multilib
     - g++-multilib
+    - libssl-dev
+    - libssl-dev:i386
     - valgrind
 
 env:
@@ -34,7 +36,7 @@ env:
   - BITS="64"
 
 script:
-  - EXTRA_CMAKE_OPTS="-DENABLE_EXAMPLES:BOOL=ON -DHIREDIS_SSL:BOOL=ON";
+  - EXTRA_CMAKE_OPTS="-DENABLE_EXAMPLES:BOOL=ON -DENABLE_SSL:BOOL=ON";
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       if [ "$BITS" == "32" ]; then
         CFLAGS="-m32 -Werror";
@@ -58,6 +60,14 @@ script:
       fi;
     fi;
     export CFLAGS CXXFLAGS LDFLAGS TEST_PREFIX EXTRA_CMAKE_OPTS
+  - make && make clean;
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      if [ "$BITS" == "64" ]; then
+        OPENSSL_PREFIX="$(ls -d /usr/local/Cellar/openssl@1.1/*)" USE_SSL=1 make;
+      fi;
+    else
+      USE_SSL=1 make;
+    fi;
   - mkdir build/ && cd build/
   - cmake .. ${EXTRA_CMAKE_OPTS}
   - make VERBOSE=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,15 @@ IF(ENABLE_SSL)
         ssl.c)
     ADD_LIBRARY(hiredis_ssl SHARED
             ${hiredis_ssl_sources})
-    SET_TARGET_PROPERTIES(hiredis_ssl
-        PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE
-        VERSION "${HIREDIS_SONAME}")
 
+    IF (APPLE)
+        SET_PROPERTY(TARGET hiredis_ssl PROPERTY LINK_FLAGS "-Wl,-undefined -Wl,dynamic_lookup")
+    ENDIF()
+
+    SET_TARGET_PROPERTIES(hiredis_ssl
+        PROPERTIES
+        WINDOWS_EXPORT_ALL_SYMBOLS TRUE
+        VERSION "${HIREDIS_SONAME}")
 
     TARGET_INCLUDE_DIRECTORIES(hiredis_ssl PRIVATE "${OPENSSL_INCLUDE_DIR}")
     TARGET_LINK_LIBRARIES(hiredis_ssl PRIVATE ${OPENSSL_LIBRARIES})


### PR DESCRIPTION
* Fix linker problems when building with SSL enabled on OSX
* Corrects `HIREDIS_SSL=ON` to `ENABLE_SSL=ON` so we test building with
  SSL enabled on travis.
* Build with both make and CMake in Travis.