### PR TITLE
Support timeouts in libev adapater

### DIFF
--- a/adapters/libev.h
+++ b/adapters/libev.h
@@ -125,7 +125,7 @@ static void redisLibevTimeout(EV_P_ ev_timer *timer, int revents) {
     redisAsyncHandleTimeout(e->context);
 }
 
-static void redisLibevScheduleTimer(void *privdata, struct timeval tv) {
+static void redisLibevSetTimeout(void *privdata, struct timeval tv) {
     redisLibevEvents *e = privdata;
     struct ev_loop *loop = e->loop;
     ((void)loop);
@@ -164,12 +164,8 @@ static int redisLibevAttach(EV_P_ redisAsyncContext *ac) {
     ac->ev.addWrite = redisLibevAddWrite;
     ac->ev.delWrite = redisLibevDelWrite;
     ac->ev.cleanup = redisLibevCleanup;
-    ac->ev.scheduleTimer = redisLibevScheduleTimer;
+    ac->ev.scheduleTimer = redisLibevSetTimeout;
     ac->ev.data = e;
-
-    if (ac->c.timeout->tv_sec != 0 || ac->c.timeout->tv_usec != 0) {
-        redisLibevScheduleTimer(e, *ac->c.timeout);
-    }
 
     /* Initialize read/write events */
     ev_io_init(&e->rev,redisLibevReadEvent,c->fd,EV_READ);

--- a/adapters/libev.h
+++ b/adapters/libev.h
@@ -41,6 +41,7 @@ typedef struct redisLibevEvents {
     struct ev_loop *loop;
     int reading, writing;
     ev_io rev, wev;
+    ev_timer timer;
 } redisLibevEvents;
 
 static void redisLibevReadEvent(EV_P_ ev_io *watcher, int revents) {
@@ -103,11 +104,39 @@ static void redisLibevDelWrite(void *privdata) {
     }
 }
 
+static void redisLibevStopTimer(void *privdata) {
+    redisLibevEvents *e = (redisLibevEvents*)privdata;
+    struct ev_loop *loop = e->loop;
+    ((void)loop);
+    ev_timer_stop(EV_A_ &e->timer);
+}
+
 static void redisLibevCleanup(void *privdata) {
     redisLibevEvents *e = (redisLibevEvents*)privdata;
     redisLibevDelRead(privdata);
     redisLibevDelWrite(privdata);
+    redisLibevStopTimer(privdata);
     free(e);
+}
+
+static void redisLibevTimeout(EV_P_ ev_timer *timer, int revents) {
+    ((void)revents);
+    redisLibevEvents *e = timer->data;
+    redisAsyncHandleTimeout(e->context);
+}
+
+static void redisLibevScheduleTimer(void *privdata, struct timeval tv) {
+    redisLibevEvents *e = privdata;
+    struct ev_loop *loop = e->loop;
+    ((void)loop);
+
+    if (!ev_is_active(&e->timer)) {
+        ev_init(&e->timer, redisLibevTimeout);
+        e->timer.data = e;
+    }
+
+    e->timer.repeat = tv.tv_sec + tv.tv_usec / 1000000.00;
+    ev_timer_again(EV_A_ &e->timer);
 }
 
 static int redisLibevAttach(EV_P_ redisAsyncContext *ac) {
@@ -119,14 +148,13 @@ static int redisLibevAttach(EV_P_ redisAsyncContext *ac) {
         return REDIS_ERR;
 
     /* Create container for context and r/w events */
-    e = (redisLibevEvents*)hi_malloc(sizeof(*e));
+    e = (redisLibevEvents*)hi_calloc(1, sizeof(*e));
     e->context = ac;
 #if EV_MULTIPLICITY
     e->loop = loop;
 #else
     e->loop = NULL;
 #endif
-    e->reading = e->writing = 0;
     e->rev.data = e;
     e->wev.data = e;
 
@@ -136,7 +164,12 @@ static int redisLibevAttach(EV_P_ redisAsyncContext *ac) {
     ac->ev.addWrite = redisLibevAddWrite;
     ac->ev.delWrite = redisLibevDelWrite;
     ac->ev.cleanup = redisLibevCleanup;
+    ac->ev.scheduleTimer = redisLibevScheduleTimer;
     ac->ev.data = e;
+
+    if (ac->c.timeout->tv_sec != 0 || ac->c.timeout->tv_usec != 0) {
+        redisLibevScheduleTimer(e, *ac->c.timeout);
+    }
 
     /* Initialize read/write events */
     ev_io_init(&e->rev,redisLibevReadEvent,c->fd,EV_READ);


### PR DESCRIPTION
Adds the ability to set a timeout when using the libev adapter.

[The libev docs around timeouts](https://metacpan.org/pod/distribution/EV/libev/ev.pod#Be-smart-about-timeouts).

They describe a variety of ways to handle timeouts with the event lib, and I went with option 2.