### PR TITLE
Use unique names for allocator struct members

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -34,11 +34,11 @@
 #include <stdlib.h>
 
 hiredisAllocFuncs hiredisAllocFns = {
-    .malloc = malloc,
-    .calloc = calloc,
-    .realloc = realloc,
-    .strdup = strdup,
-    .free = free,
+    .mallocFn = malloc,
+    .callocFn = calloc,
+    .reallocFn = realloc,
+    .strdupFn = strdup,
+    .freeFn = free,
 };
 
 /* Override hiredis' allocators with ones supplied by the user */
@@ -53,34 +53,34 @@ hiredisAllocFuncs hiredisSetAllocators(hiredisAllocFuncs *override) {
 /* Reset allocators to use libc defaults */
 void hiredisResetAllocators(void) {
     hiredisAllocFns = (hiredisAllocFuncs) {
-        .malloc = malloc,
-        .calloc = calloc,
-        .realloc = realloc,
-        .strdup = strdup,
-        .free = free,
+        .mallocFn = malloc,
+        .callocFn = calloc,
+        .reallocFn = realloc,
+        .strdupFn = strdup,
+        .freeFn = free,
     };
 }
 
 #ifdef _WIN32
 
 void *hi_malloc(size_t size) {
-    return hiredisAllocFns.malloc(size);
+    return hiredisAllocFns.mallocFn(size);
 }
 
 void *hi_calloc(size_t nmemb, size_t size) {
-    return hiredisAllocFns.calloc(nmemb, size);
+    return hiredisAllocFns.callocFn(nmemb, size);
 }
 
 void *hi_realloc(void *ptr, size_t size) {
-    return hiredisAllocFns.realloc(ptr, size);
+    return hiredisAllocFns.reallocFn(ptr, size);
 }
 
 char *hi_strdup(const char *str) {
-    return hiredisAllocFns.strdup(str);
+    return hiredisAllocFns.strdupFn(str);
 }
 
 void hi_free(void *ptr) {
-    hiredisAllocFns.free(ptr);
+    hiredisAllocFns.freeFn(ptr);
 }
 
 #endif

--- a/alloc.h
+++ b/alloc.h
@@ -39,11 +39,11 @@ extern "C" {
 
 /* Structure pointing to our actually configured allocators */
 typedef struct hiredisAllocFuncs {
-    void *(*malloc)(size_t);
-    void *(*calloc)(size_t,size_t);
-    void *(*realloc)(void*,size_t);
-    char *(*strdup)(const char*);
-    void (*free)(void*);
+    void *(*mallocFn)(size_t);
+    void *(*callocFn)(size_t,size_t);
+    void *(*reallocFn)(void*,size_t);
+    char *(*strdupFn)(const char*);
+    void (*freeFn)(void*);
 } hiredisAllocFuncs;
 
 hiredisAllocFuncs hiredisSetAllocators(hiredisAllocFuncs *ha);
@@ -55,23 +55,23 @@ void hiredisResetAllocators(void);
 extern hiredisAllocFuncs hiredisAllocFns;
 
 static inline void *hi_malloc(size_t size) {
-    return hiredisAllocFns.malloc(size);
+    return hiredisAllocFns.mallocFn(size);
 }
 
 static inline void *hi_calloc(size_t nmemb, size_t size) {
-    return hiredisAllocFns.calloc(nmemb, size);
+    return hiredisAllocFns.callocFn(nmemb, size);
 }
 
 static inline void *hi_realloc(void *ptr, size_t size) {
-    return hiredisAllocFns.realloc(ptr, size);
+    return hiredisAllocFns.reallocFn(ptr, size);
 }
 
 static inline char *hi_strdup(const char *str) {
-    return hiredisAllocFns.strdup(str);
+    return hiredisAllocFns.strdupFn(str);
 }
 
 static inline void hi_free(void *ptr) {
-    hiredisAllocFns.free(ptr);
+    hiredisAllocFns.freeFn(ptr);
 }
 
 #else

--- a/test.c
+++ b/test.c
@@ -547,10 +547,10 @@ static void *hi_realloc_fail(void *ptr, size_t size) {
 
 static void test_allocator_injection(void) {
     hiredisAllocFuncs ha = {
-        .malloc = hi_malloc_fail,
-        .calloc = hi_calloc_fail,
-        .realloc = hi_realloc_fail,
-        .free = NULL,
+        .mallocFn = hi_malloc_fail,
+        .callocFn = hi_calloc_fail,
+        .reallocFn = hi_realloc_fail,
+        .freeFn = NULL,
     };
 
     // Override hiredis allocators


### PR DESCRIPTION
Using `strdup` as a struct member causes issues in older gcc

cc @carlosabalde I think this should fix it for you (it fixed it for me with gcc-5.4.0 in a xenial docker container)

[See context here](https://github.com/redis/hiredis/commit/8e0264cfd6889b73c241b60736fe96ba1322ee6e#commitcomment-39413269)