### PR TITLE
pass MSG_NOSIGNAL to send in order to prevent signal generation.

### DIFF
--- a/net.c
+++ b/net.c
@@ -80,7 +80,7 @@ ssize_t redisNetRead(redisContext *c, char *buf, size_t bufcap) {
 }
 
 ssize_t redisNetWrite(redisContext *c) {
-    ssize_t nwritten = send(c->fd, c->obuf, sdslen(c->obuf), 0);
+    ssize_t nwritten = send(c->fd, c->obuf, sdslen(c->obuf), MSG_NOSIGNAL);
     if (nwritten < 0) {
         if ((errno == EWOULDBLOCK && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
             /* Try again later */


### PR DESCRIPTION
When the connection to the redis server breaks a call to send will generate a SIGPIPE signal.
In applications where multiple connections are handles this behavior makes handling broken connections really hard.
However, passing MSG_NOSIGNAL to send solves this as proper error propagation is already implemented in the error handling code just after send