### PR TITLE
Resp3 oob push support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /*.a
 /*.pc
 *.dSYM
+tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,10 +102,7 @@ jobs:
         - eval "${MATRIX_EVAL}"
       install:
         - choco install ninja
-        - choco install redis-64 -y
-      before_script:
-        - redis-server --service-install --service-name Redis --port 6379
-        - redis-server --service-start
+        - choco install -y memurai-developer
       script:
         - mkdir build && cd build
         - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_script:
 
 addons:
   apt:
+    sources:
+    - sourceline: 'ppa:chris-lea/redis-server'
     packages:
     - libc6-dbg
     - libc6-dev
@@ -30,6 +32,7 @@ addons:
     - libssl-dev
     - libssl-dev:i386
     - valgrind
+    - redis
 
 env:
   - BITS="32"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 OBJ=alloc.o net.o hiredis.o sds.o async.o read.o sockcompat.o
 SSL_OBJ=ssl.o
-EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib
+EXAMPLES=hiredis-example hiredis-example-libevent hiredis-example-libev hiredis-example-glib hiredis-example-push
 ifeq ($(USE_SSL),1)
 EXAMPLES+=hiredis-example-ssl hiredis-example-libevent-ssl
 endif
@@ -161,6 +161,7 @@ hiredis-example-macosx: examples/example-macosx.c adapters/macosx.h $(STLIBNAME)
 hiredis-example-ssl: examples/example-ssl.c $(STLIBNAME) $(SSL_STLIBNAME)
 	$(CC) -o examples/$@ $(REAL_CFLAGS) -I. $< $(STLIBNAME) $(SSL_STLIBNAME) $(REAL_LDFLAGS) $(SSL_LDFLAGS)
 
+
 ifndef AE_DIR
 hiredis-example-ae:
 	@echo "Please specify AE_DIR (e.g. <redis repository>/src)"
@@ -193,6 +194,9 @@ hiredis-example-qt: examples/example-qt.cpp adapters/qt.h $(STLIBNAME)
 endif
 
 hiredis-example: examples/example.c $(STLIBNAME)
+	$(CC) -o examples/$@ $(REAL_CFLAGS) -I. $< $(STLIBNAME) $(REAL_LDFLAGS)
+
+hiredis-example-push: examples/example-push.c $(STLIBNAME)
 	$(CC) -o examples/$@ $(REAL_CFLAGS) -I. $< $(STLIBNAME) $(REAL_LDFLAGS)
 
 examples: $(EXAMPLES)

--- a/async.c
+++ b/async.c
@@ -477,7 +477,7 @@ oom:
 #define redisIsSpontaneousPushReply(r) \
     (redisIsPushReply(r) && !redisIsSubscribeReply(r))
 
-static inline int redisIsSubscribeReply(redisReply *reply) {
+static int redisIsSubscribeReply(redisReply *reply) {
     char *str;
     size_t len, off;
 

--- a/async.c
+++ b/async.c
@@ -279,6 +279,14 @@ static void __redisRunCallback(redisAsyncContext *ac, redisCallback *cb, redisRe
     }
 }
 
+static void __redisRunPushCallback(redisAsyncContext *ac, redisReply *reply) {
+    redisContext *c = &(ac->c);
+
+    c->flags |= REDIS_IN_CALLBACK;
+    if (c->push_cb) c->push_cb(reply);
+    c->flags &= ~REDIS_IN_CALLBACK;
+}
+
 /* Helper function to free the context. */
 static void __redisAsyncFree(redisAsyncContext *ac) {
     redisContext *c = &(ac->c);
@@ -294,7 +302,7 @@ static void __redisAsyncFree(redisAsyncContext *ac) {
     while (__redisShiftCallback(&ac->sub.invalid,&cb) == REDIS_OK)
         __redisRunCallback(ac,&cb,NULL);
 
-    /* Run subscription callbacks callbacks with NULL reply */
+    /* Run subscription callbacks with NULL reply */
     if (ac->sub.channels) {
         it = dictGetIterator(ac->sub.channels);
         if (it != NULL) {
@@ -459,6 +467,27 @@ oom:
     return REDIS_ERR;
 }
 
+static inline int redisIsSubscribeReply(redisReply *reply) {
+    char *str;
+    size_t len, off;
+
+    /* We will always have at least one string with the subscribe/message type */
+    if (reply->elements < 1 || reply->element[0]->type != REDIS_REPLY_STRING ||
+        reply->element[0]->len < sizeof("message") - 1)
+    {
+        return 0;
+    }
+
+    /* Get the string/len moving past 'p' if needed */
+    off = tolower(reply->element[0]->str[0]) == 'p';
+    str = reply->element[0]->str + off;
+    len = reply->element[0]->len - off;
+
+    return !strncasecmp(str, "subscribe", len) ||
+           !strncasecmp(str, "message", len);
+
+}
+
 void redisProcessCallbacks(redisAsyncContext *ac) {
     redisContext *c = &(ac->c);
     redisCallback cb = {NULL, NULL, 0, NULL};
@@ -485,8 +514,18 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
             break;
         }
 
-        /* Even if the context is subscribed, pending regular callbacks will
-         * get a reply before pub/sub messages arrive. */
+        /* Send any non-subscribe related PUSH messages to our PUSH handler
+         * while allowing subscribe related PUSH messages to pass through.
+         * This allows existing code to be backward compatible and work in
+         * either RESP2 or RESP3 mode. */
+        if (redisIsPushReply(reply) && !redisIsSubscribeReply(reply)) {
+            __redisRunPushCallback(ac, reply);
+            c->reader->fn->freeObject(reply);
+            continue;
+        }
+
+        /* Even if the context is subscribed, pending regular
+         * callbacks will get a reply before pub/sub messages arrive. */
         if (__redisShiftCallback(&ac->replies,&cb) != REDIS_OK) {
             /*
              * A spontaneous reply in a not-subscribed context can be the error
@@ -807,6 +846,10 @@ int redisAsyncCommandArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *priv
 int redisAsyncFormattedCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *cmd, size_t len) {
     int status = __redisAsyncCommand(ac,fn,privdata,cmd,len);
     return status;
+}
+
+redisPushHandler *redisAsyncSetPushHandler(redisAsyncContext *ac, redisPushHandler *fn) {
+    return redisSetPushHandler(&ac->c, fn);
 }
 
 int redisAsyncSetTimeout(redisAsyncContext *ac, struct timeval tv) {

--- a/async.c
+++ b/async.c
@@ -167,10 +167,9 @@ redisAsyncContext *redisAsyncConnectWithOptions(const redisOptions *options) {
     redisContext *c;
     redisAsyncContext *ac;
 
-    /* If the user hasn't specified a PUSH handler, then flag that we don't
-     * want one at all (we will still free the reply with freeReplyObject) */
-    if (myOptions.push_cb == NULL)
-        myOptions.options |= REDIS_OPT_NO_PUSH_HANDLER;
+    /* We always free replies for the user in async hiredis so don't default
+     * to freeReplyObject if the user doesn't set a handler. */
+    myOptions.options |= REDIS_OPT_NO_PUSH_AUTOFREE;
 
     myOptions.options |= REDIS_OPT_NONBLOCK;
     c = redisConnectWithOptions(&myOptions);

--- a/async.c
+++ b/async.c
@@ -292,7 +292,7 @@ static void __redisRunCallback(redisAsyncContext *ac, redisCallback *cb, redisRe
 static void __redisRunPushCallback(redisAsyncContext *ac, redisReply *reply) {
     if (ac->push_cb != NULL) {
         ac->c.flags |= REDIS_IN_CALLBACK;
-        ac->push_cb(ac, reply, NULL);
+        ac->push_cb(ac, reply);
         ac->c.flags &= ~REDIS_IN_CALLBACK;
     }
 }

--- a/async.h
+++ b/async.h
@@ -118,6 +118,7 @@ redisAsyncContext *redisAsyncConnectUnix(const char *path);
 int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn);
 int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn);
 
+redisPushHandler *redisAsyncSetPushHandler(redisAsyncContext *ac, redisPushHandler *fn);
 int redisAsyncSetTimeout(redisAsyncContext *ac, struct timeval tv);
 void redisAsyncDisconnect(redisAsyncContext *ac);
 void redisAsyncFree(redisAsyncContext *ac);

--- a/async.h
+++ b/async.h
@@ -106,6 +106,9 @@ typedef struct redisAsyncContext {
         struct dict *channels;
         struct dict *patterns;
     } sub;
+
+    /* Any configured RESP3 PUSH handler */
+    redisAsyncPushFn *push_cb;
 } redisAsyncContext;
 
 /* Functions that proxy to hiredis */
@@ -118,7 +121,7 @@ redisAsyncContext *redisAsyncConnectUnix(const char *path);
 int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn);
 int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn);
 
-redisPushHandler *redisAsyncSetPushHandler(redisAsyncContext *ac, redisPushHandler *fn);
+redisAsyncPushFn *redisAsyncSetPushCallback(redisAsyncContext *ac, redisAsyncPushFn *fn);
 int redisAsyncSetTimeout(redisAsyncContext *ac, struct timeval tv);
 void redisAsyncDisconnect(redisAsyncContext *ac);
 void redisAsyncFree(redisAsyncContext *ac);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -44,3 +44,6 @@ ENDIF()
 
 ADD_EXECUTABLE(example example.c)
 TARGET_LINK_LIBRARIES(example hiredis)
+
+ADD_EXECUTABLE(example-push example-push.c)
+TARGET_LINK_LIBRARIES(example-push hiredis)

--- a/examples/example-push.c
+++ b/examples/example-push.c
@@ -30,7 +30,7 @@ static void assertReplyAndFree(redisContext *context, redisReply *reply, int typ
 static void enableClientTracking(redisContext *c) {
     redisReply *reply = redisCommand(c, "HELLO 3");
     if (reply == NULL || c->err) {
-        panicAbort("NULL reply or server error (error: %s)", c->err ? c->errstr : "(none)");
+        panicAbort("NULL reply or server error (error: %s)", c->errstr);
     }
 
     if (reply->type != REDIS_REPLY_MAP) {
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
      * time our PUSH handler is called, hiredis will pass the privdata for context */
     c->privdata = &invalidations;
 
-    /* Set some keys and then read their data back.  Once we do that, Redis will deliver
+    /* Set some keys and then read them back.  Once we do that, Redis will deliver
      * invalidation push messages whenever the key is modified */
     for (j = 0; j < KEY_COUNT; j++) {
         reply = redisCommand(c, "SET key:%d initial:%d", j, j);
@@ -103,8 +103,7 @@ int main(int argc, char **argv) {
         assertReplyAndFree(c, reply, REDIS_REPLY_STRING);
     }
 
-    /* Now each of these SET commands will generate an invalidation message, which
-     * will trigger pushReplyHandler. */
+    /* Trigger invalidation messages by updating keys we just read */
     for (j = 0; j < KEY_COUNT; j++) {
         printf("            main(): SET key:%d update:%d\n", j, j);
         reply = redisCommand(c, "SET key:%d update:%d", j, j);

--- a/examples/example-push.c
+++ b/examples/example-push.c
@@ -1,0 +1,119 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <hiredis.h>
+#include <win32.h>
+
+#define KEY_COUNT 5
+
+#define panicAbort(fmt, ...) \
+    do { \
+        fprintf(stderr, "%s:%d:%s(): " fmt, __FILE__, __LINE__, __func__, __VA_ARGS__); \
+        exit(-1); \
+    } while (0)
+
+static void assertReplyAndFree(redisContext *context, redisReply *reply, int type) {
+    if (reply == NULL)
+        panicAbort("NULL reply from server (error: %s)", context->errstr);
+
+    if (reply->type != type) {
+        if (reply->type == REDIS_REPLY_ERROR)
+            fprintf(stderr, "Redis Error: %s\n", reply->str);
+
+        panicAbort("Expected reply type %d but got type %d", type, reply->type);
+    }
+
+    freeReplyObject(reply);
+}
+
+/* Switch to the RESP3 protocol and enable client tracking */
+static void enableClientTracking(redisContext *c) {
+    redisReply *reply = redisCommand(c, "HELLO 3");
+    if (reply == NULL || c->err) {
+        panicAbort("NULL reply or server error (error: %s)", c->err ? c->errstr : "(none)");
+    }
+
+    if (reply->type != REDIS_REPLY_MAP) {
+        fprintf(stderr, "Error: Can't send HELLO 3 command.  Are you sure you're ");
+        fprintf(stderr, "connected to redis-server >= 6.0.0?\nRedis error: %s\n",
+                        reply->type == REDIS_REPLY_ERROR ? reply->str : "(unknown)");
+        exit(-1);
+    }
+
+    freeReplyObject(reply);
+
+    /* Enable client tracking */
+    reply = redisCommand(c, "CLIENT TRACKING ON");
+    assertReplyAndFree(c, reply, REDIS_REPLY_STATUS);
+}
+
+void pushReplyHandler(void *privdata, void *r) {
+    redisReply *reply = r;
+    int *invalidations = privdata;
+
+    /* Sanity check on the invalidation reply */
+    if (reply->type != REDIS_REPLY_PUSH || reply->elements != 2 ||
+        reply->element[1]->type != REDIS_REPLY_ARRAY ||
+        reply->element[1]->element[0]->type != REDIS_REPLY_STRING)
+    {
+        panicAbort("%s", "Can't parse PUSH message!");
+    }
+
+    /* Increment our invalidation count */
+    *invalidations += 1;
+
+    printf("pushReplyHandler(): INVALIDATE '%s' (invalidation count: %d)\n",
+           reply->element[1]->element[0]->str, *invalidations);
+
+    freeReplyObject(reply);
+}
+
+int main(int argc, char **argv) {
+    unsigned int j, invalidations = 0;
+    redisContext *c;
+    redisReply *reply;
+
+    const char *hostname = (argc > 1) ? argv[1] : "127.0.0.1";
+    int port = (argc > 2) ? atoi(argv[2]) : 6379;
+
+    redisOptions o = {0};
+    REDIS_OPTIONS_SET_TCP(&o, hostname, port);
+
+    /* Set our custom PUSH message handler */
+    o.push_cb = pushReplyHandler;
+
+    c = redisConnectWithOptions(&o);
+    if (c == NULL || c->err)
+        panicAbort("Connection error:  %s", c ? c->errstr : "OOM");
+
+    /* Enable RESP3 and turn on client tracking */
+    enableClientTracking(c);
+
+    /* Set our context privdata to the address of our invalidation counter.  Each
+     * time our PUSH handler is called, hiredis will pass the privdata for context */
+    c->privdata = &invalidations;
+
+    /* Set some keys and then read their data back.  Once we do that, Redis will deliver
+     * invalidation push messages whenever the key is modified */
+    for (j = 0; j < KEY_COUNT; j++) {
+        reply = redisCommand(c, "SET key:%d initial:%d", j, j);
+        assertReplyAndFree(c, reply, REDIS_REPLY_STATUS);
+
+        reply = redisCommand(c, "GET key:%d", j);
+        assertReplyAndFree(c, reply, REDIS_REPLY_STRING);
+    }
+
+    /* Now each of these SET commands will generate an invalidation message, which
+     * will trigger pushReplyHandler. */
+    for (j = 0; j < KEY_COUNT; j++) {
+        printf("            main(): SET key:%d update:%d\n", j, j);
+        reply = redisCommand(c, "SET key:%d update:%d", j, j);
+        assertReplyAndFree(c, reply, REDIS_REPLY_STATUS);
+        printf("            main(): SET REPLY OK\n");
+    }
+
+    printf("\nTotal detected invalidations: %d, expected: %d\n", invalidations, KEY_COUNT);
+
+    /* PING server */
+    redisFree(c);
+}

--- a/hiredis.c
+++ b/hiredis.c
@@ -688,7 +688,13 @@ static redisContext *redisContextInit(const redisOptions *options) {
         return NULL;
 
     c->funcs = &redisContextDefaultFuncs;
-    c->push_cb = options->push_cb;
+
+    /* Set any user supplied RESP3 PUSH handler or use freeReplyObject
+     * as a default unless specifically flagged that we don't want one. */
+    if (c->push_cb != NULL)
+        redisSetPushHandler(c, options->push_cb);
+    else if (!(options->options & REDIS_OPT_NO_PUSH_HANDLER))
+        redisSetPushHandler(c, freeReplyObject);
 
     c->obuf = sdsempty();
     c->reader = redisReaderCreate();

--- a/hiredis.c
+++ b/hiredis.c
@@ -691,9 +691,9 @@ static redisContext *redisContextInit(const redisOptions *options) {
 
     /* Set any user supplied RESP3 PUSH handler or use freeReplyObject
      * as a default unless specifically flagged that we don't want one. */
-    if (c->push_cb != NULL)
+    if (options->push_cb != NULL)
         redisSetPushHandler(c, options->push_cb);
-    else if (!(options->options & REDIS_OPT_NO_PUSH_HANDLER))
+    else if (!(options->options & REDIS_OPT_NO_PUSH_AUTOFREE))
         redisSetPushHandler(c, freeReplyObject);
 
     c->obuf = sdsempty();

--- a/hiredis.h
+++ b/hiredis.h
@@ -92,6 +92,11 @@ typedef long long ssize_t;
  * SO_REUSEADDR is being used. */
 #define REDIS_CONNECT_RETRIES  10
 
+/* RESP3 push helpers and callback prototype */
+#define redisIsPushReply(r) (((redisReply*)(r))->type == REDIS_REPLY_PUSH)
+typedef void (redisPushHandler)(void*);
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -180,6 +185,9 @@ typedef struct {
          * file descriptor */
         redisFD fd;
     } endpoint;
+
+    /* A user defined PUSH message callback */
+    redisPushHandler *push_cb;
 } redisOptions;
 
 /**
@@ -235,6 +243,9 @@ typedef struct redisContext {
 
     /* Additional private data for hiredis addons such as SSL */
     void *privdata;
+
+    /* An optional RESP3 PUSH handler */
+    redisPushHandler *push_cb;
 } redisContext;
 
 redisContext *redisConnectWithOptions(const redisOptions *options);
@@ -261,6 +272,7 @@ redisContext *redisConnectFd(redisFD fd);
  */
 int redisReconnect(redisContext *c);
 
+redisPushHandler *redisSetPushHandler(redisContext *c, redisPushHandler *fn);
 int redisSetTimeout(redisContext *c, const struct timeval tv);
 int redisEnableKeepAlive(redisContext *c);
 void redisFree(redisContext *c);

--- a/hiredis.h
+++ b/hiredis.h
@@ -145,6 +145,9 @@ struct redisSsl;
  */
 #define REDIS_OPT_NOAUTOFREE 0x04
 
+/* Don't specify a RESP3 PUSH handler */
+#define REDIS_OPT_NO_PUSH_HANDLER 0x08
+
 /* In Unix systems a file descriptor is a regular signed int, with -1
  * representing an invalid descriptor. In Windows it is a SOCKET
  * (32- or 64-bit unsigned integer depending on the architecture), where

--- a/hiredis.h
+++ b/hiredis.h
@@ -145,8 +145,8 @@ struct redisSsl;
  */
 #define REDIS_OPT_NOAUTOFREE 0x04
 
-/* Don't specify a RESP3 PUSH handler */
-#define REDIS_OPT_NO_PUSH_HANDLER 0x08
+/* Don't automatically intercept and free RESP3 PUSH replies. */
+#define REDIS_OPT_NO_PUSH_AUTOFREE 0x08
 
 /* In Unix systems a file descriptor is a regular signed int, with -1
  * representing an invalid descriptor. In Windows it is a SOCKET

--- a/hiredis.h
+++ b/hiredis.h
@@ -99,7 +99,7 @@ struct redisContext;
 /* RESP3 push helpers and callback prototypes */
 #define redisIsPushReply(r) (((redisReply*)(r))->type == REDIS_REPLY_PUSH)
 typedef void (redisPushFn)(void *, void *);
-typedef void (redisAsyncPushFn)(struct redisAsyncContext *, void *, void *);
+typedef void (redisAsyncPushFn)(struct redisAsyncContext *, void *);
 
 #ifdef __cplusplus
 extern "C" {

--- a/test.c
+++ b/test.c
@@ -735,13 +735,13 @@ static void test_resp3_push_options(struct config config) {
     redisContext *c;
     redisOptions options;
 
-    test("RESP3 push handler defaults to freeReplyObject for redisContext: ");
+    test("We set a default RESP3 handler for redisContext: ");
     options = get_redis_tcp_options(config);
     assert((c = redisConnectWithOptions(&options)) != NULL);
-    test_cond(c->push_cb == freeReplyObject);
+    test_cond(c->push_cb != NULL);
     redisFree(c);
 
-    test("RESP3 push handler defaults to NULL for redisAsyncContext: ");
+    test("We don't set a default RESP3 push handler for redisAsyncContext: ");
     options = get_redis_tcp_options(config);
     assert((ac = redisAsyncConnectWithOptions(&options)) != NULL);
     test_cond(ac->c.push_cb == NULL);

--- a/test.c
+++ b/test.c
@@ -120,6 +120,8 @@ void get_redis_version(redisContext *c, int *major, int *minor) {
         *major = strtol(vstr, &eptr, 10);
     if (minor)
         *minor = strtol(eptr+1, &eptr, 10);
+
+    sdsfree(vstr);
 }
 
 static redisContext *select_database(redisContext *c) {
@@ -681,8 +683,8 @@ static void test_blocking_connection_errors(void) {
 }
 
 void push_handler(void *r) {
-    (void)r;
     push_counter++;
+    freeReplyObject(r);
 }
 
 static void test_resp3_push_handler(redisContext *c) {
@@ -701,6 +703,7 @@ static void test_resp3_push_handler(redisContext *c) {
     test("RESP3 PUSH messages are handled out of band by default: ");
     reply = redisCommand(c, "SET key:0 val:0");
     test_cond(reply != NULL && reply->type == REDIS_REPLY_STATUS);
+    freeReplyObject(reply);
 
     reply = redisCommand(c, "GET key:0");
     assert(reply != NULL);

--- a/test.c
+++ b/test.c
@@ -681,10 +681,9 @@ void push_handler(void *privdata, void *reply) {
 }
 
 /* Dummy function just to test setting a callback with redisOptions */
-void push_handler_async(redisAsyncContext *ac, void *reply, void *reserved) {
+void push_handler_async(redisAsyncContext *ac, void *reply) {
     (void)ac;
     (void)reply;
-    (void)reserved;
 }
 
 static void test_resp3_push_handler(redisContext *c) {


### PR DESCRIPTION
Implement proper RESP3 push message support in both sync and async hiredis.

The change intercepts `RESP3` PUSH messages by default in sync hiredis and calls `freeReplyObject` when they are received.  If the user wishes to do something specific with the replies they can either set a handler up in `redisOptions` or specify a handler after connected with `redisSetPushHandler`

This works similarly in async hiredis except we always call `freeObject` regardless of whether the user has specified an additional handler (because async hiredis always frees replies).

It also adds some tests (in Linux) for the handler by using Chris Lea's Redis PPA (so we can test against Redis 6.0.x).

See: #825

cc: @yossigo, @lukepalmer 