### PR TITLE
Use _WIN32 instead of WIN32 define

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,10 +99,7 @@ jobs:
         - eval "${MATRIX_EVAL}"
       install:
         - choco install ninja
-        - choco install redis-64 -y
-      before_script:
-        - redis-server --service-install --service-name Redis --port 6379
-        - redis-server --service-start
+        - choco install -y memurai-developer
       script:
         - mkdir build && cd build
         - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&'

--- a/ssl.c
+++ b/ssl.c
@@ -36,7 +36,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <string.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #else
 #include <pthread.h>
@@ -95,7 +95,7 @@ redisContextFuncs redisContextSSLFuncs;
 #endif
 
 #ifdef HIREDIS_USE_CRYPTO_LOCKS
-#ifdef WIN32
+#ifdef _WIN32
 typedef CRITICAL_SECTION sslLockType;
 static void sslLockInit(sslLockType* l) {
     InitializeCriticalSection(l);


### PR DESCRIPTION
It looks like `_WIN32` is always defined whereas `WIN32` may not be.