### PR TITLE
Non Linux CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,12 @@ branches:
     - /^release\/.*$/
 
 before_script:
-    - if [ "$TRAVIS_OS_NAME" == "osx" ] ; then brew update; brew install redis openssl; fi
+    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        curl -O https://distfiles.macports.org/MacPorts/MacPorts-2.6.2-10.13-HighSierra.pkg;
+        sudo installer -pkg MacPorts-2.6.2-10.13-HighSierra.pkg -target /;
+        export PATH=$PATH:/opt/local/bin && sudo port -v selfupdate;
+        sudo port -N install openssl redis;
+      fi;
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,10 +99,7 @@ jobs:
         - eval "${MATRIX_EVAL}"
       install:
         - choco install ninja
-        - choco install redis-64 -y
-      before_script:
-        - redis-server --service-install --service-name Redis --port 6379
-        - redis-server --service-start
+        - choco install -y memurai-developer
       script:
         - mkdir build && cd build
         - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&'


### PR DESCRIPTION
Homebrew on Travis takes forever to spin up and seems to have recently broken.  This commit switches to Mac Ports which fixes the tests, makes them faster (~2x) and gives us access to Redis 6.0.5 in our OSX tests.

The `redis-64` choco package is unmaintained so the commit switches to Memurai.