### PR TITLE
Some Windows quality of life improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,5 +108,5 @@ jobs:
       script:
         - mkdir build && cd build
         - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&'
-          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release '&&' ninja -v
+          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_EXAMPLES=ON '&&' ninja -v
         - ./hiredis-test.exe

--- a/examples/example-ivykis.c
+++ b/examples/example-ivykis.c
@@ -33,7 +33,9 @@ void disconnectCallback(const redisAsyncContext *c, int status) {
 }
 
 int main (int argc, char **argv) {
+#ifndef _WIN32
     signal(SIGPIPE, SIG_IGN);
+#endif
 
     iv_init();
 

--- a/examples/example-libev.c
+++ b/examples/example-libev.c
@@ -33,7 +33,9 @@ void disconnectCallback(const redisAsyncContext *c, int status) {
 }
 
 int main (int argc, char **argv) {
+#ifndef _WIN32
     signal(SIGPIPE, SIG_IGN);
+#endif
 
     redisAsyncContext *c = redisAsyncConnect("127.0.0.1", 6379);
     if (c->err) {

--- a/examples/example-libevent-ssl.c
+++ b/examples/example-libevent-ssl.c
@@ -34,7 +34,10 @@ void disconnectCallback(const redisAsyncContext *c, int status) {
 }
 
 int main (int argc, char **argv) {
+#ifndef _WIN32
     signal(SIGPIPE, SIG_IGN);
+#endif
+
     struct event_base *base = event_base_new();
     if (argc < 5) {
         fprintf(stderr,

--- a/examples/example-libevent.c
+++ b/examples/example-libevent.c
@@ -38,7 +38,10 @@ void disconnectCallback(const redisAsyncContext *c, int status) {
 }
 
 int main (int argc, char **argv) {
+#ifndef _WIN32
     signal(SIGPIPE, SIG_IGN);
+#endif
+
     struct event_base *base = event_base_new();
     redisOptions options = {0};
     REDIS_OPTIONS_SET_TCP(&options, "127.0.0.1", 6379);

--- a/examples/example-libuv.c
+++ b/examples/example-libuv.c
@@ -33,7 +33,10 @@ void disconnectCallback(const redisAsyncContext *c, int status) {
 }
 
 int main (int argc, char **argv) {
+#ifndef _WIN32
     signal(SIGPIPE, SIG_IGN);
+#endif
+
     uv_loop_t* loop = uv_default_loop();
 
     redisAsyncContext *c = redisAsyncConnect("127.0.0.1", 6379);

--- a/examples/example-ssl.c
+++ b/examples/example-ssl.c
@@ -4,6 +4,7 @@
 
 #include <hiredis.h>
 #include <hiredis_ssl.h>
+#include <win32.h>
 
 int main(int argc, char **argv) {
     unsigned int j;

--- a/examples/example.c
+++ b/examples/example.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <hiredis.h>
+#include <win32.h>
 
 int main(int argc, char **argv) {
     unsigned int j, isunix = 0;


### PR DESCRIPTION
* Don't try to ignore SIGPIPE in Windows (it doesn't exist).
* Add an include to our win32.h compatibility header.
* Enable building examples on Travis in Windows.

See #831