### PR TITLE
Don't use non-installed win32.h helper in examples

### DIFF
--- a/examples/example-push.c
+++ b/examples/example-push.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <hiredis.h>
-#include <win32.h>
 
 #define KEY_COUNT 5
 

--- a/examples/example-ssl.c
+++ b/examples/example-ssl.c
@@ -4,7 +4,10 @@
 
 #include <hiredis.h>
 #include <hiredis_ssl.h>
-#include <win32.h>
+
+#ifdef _MSC_VER
+#include <winsock2.h> /* For struct timeval */
+#endif
 
 int main(int argc, char **argv) {
     unsigned int j;

--- a/examples/example.c
+++ b/examples/example.c
@@ -2,7 +2,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <hiredis.h>
-#include <win32.h>
+
+#ifdef _MSC_VER
+#include <winsock2.h> /* For struct timeval */
+#endif
 
 int main(int argc, char **argv) {
     unsigned int j, isunix = 0;


### PR DESCRIPTION
We can just pull winsock2.h directly if we need `timeval`

See: #862