### PR TITLE
TLS: Validate the hostname of the server certificate

### DIFF
--- a/hiredis_ssl.h
+++ b/hiredis_ssl.h
@@ -88,8 +88,9 @@ int redisInitOpenSSL(void);
  * certificate and private key files to use for authentication. They need to
  * be both specified or omitted.
  *
- * server_name is an optional and will be used as a server name indication
- * (SNI) TLS extension.
+ * server_name is optional and will be used as a server name indication (SNI)
+ * TLS extension and to validate the hostname of the server's certificate
+ * (this requires OpenSSL 1.1.0 or newer).
  *
  * If error is non-null, it will be populated in case the context creation fails
  * (returning a NULL).

--- a/ssl.c
+++ b/ssl.c
@@ -44,6 +44,7 @@
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/x509v3.h>
 
 #include "win32.h"
 #include "async_private.h"
@@ -84,6 +85,14 @@ typedef struct redisSSL {
 
 /* Forward declaration */
 redisContextFuncs redisContextSSLFuncs;
+
+/**
+ * OpenSSL hostname validation for OpenSSL >= 1.1.0
+ * Reference: https://wiki.openssl.org/index.php/Hostname_validation
+ */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#define HIREDIS_CHECK_SSL_SERVER_NAME
+#endif
 
 /**
  * OpenSSL global initialization and locking handling callbacks.
@@ -348,9 +357,18 @@ int redisInitiateSSLWithContext(redisContext *c, redisSSLContext *redis_ssl_ctx)
 
     if (redis_ssl_ctx->server_name) {
         if (!SSL_set_tlsext_host_name(ssl, redis_ssl_ctx->server_name)) {
-            __redisSetError(c, REDIS_ERR_OTHER, "Failed to set server_name/SNI");
+            __redisSetError(c, REDIS_ERR_OTHER,
+                "Failed to set server name for SNI");
             goto error;
         }
+#ifdef HIREDIS_CHECK_SSL_SERVER_NAME
+        SSL_set_hostflags(ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+        if (!SSL_set1_host(ssl, redis_ssl_ctx->server_name)) {
+            __redisSetError(c, REDIS_ERR_OTHER,
+                "Failed to set server name for certificate validation");
+            goto error;
+        }
+#endif
     }
 
     return redisSSLConnect(c, ssl);


### PR DESCRIPTION
Avoid MITM attacks by checking whether the server's certificate contains the server's hostname.

Currently this works only with OpenSSL 1.1.0 or newer.