### PR TITLE
CMakeLists.txt: allow building without a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.4.0)
-INCLUDE(GNUInstallDirs)
-PROJECT(hiredis)
 
 OPTION(ENABLE_SSL "Build hiredis_ssl for SSL support" OFF)
 OPTION(DISABLE_TESTS "If tests should be compiled or not" OFF)
@@ -20,7 +18,8 @@ getVersionBit(HIREDIS_SONAME)
 SET(VERSION "${HIREDIS_MAJOR}.${HIREDIS_MINOR}.${HIREDIS_PATCH}")
 MESSAGE("Detected version: ${VERSION}")
 
-PROJECT(hiredis VERSION "${VERSION}")
+PROJECT(hiredis LANGUAGES "C" VERSION "${VERSION}")
+INCLUDE(GNUInstallDirs)
 
 # Hiredis requires C99
 SET(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
Define hiredis as a C project (and use a single `PROJECT` statement) to
avoid the following build failure if a C++ compiler is not found:

```
CMake Error at CMakeLists.txt:3 (PROJECT):
  The CMAKE_CXX_COMPILER:

    /srv/storage/autobuild/run/instance-1/output-1/host/bin/arm-linux-g++

  is not a full path to an existing compiler tool.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```

The only cpp source file is examples/example-qt.cpp which is never
compiled with cmake buildsystem. This file is compiled only with the
Makefile buildsystem so perhaps it should be removed. If it is added to
the cmake buildsystem, a call to `enable_language(CXX)` will have to be
added.

Fixes:
 - http://autobuild.buildroot.org/results/830ec3398cd29b9fc5cde06a225ef531d7a9d850

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>