### PR TITLE
Copy error to redisAsyncContext on timeout

### DIFF
--- a/async.c
+++ b/async.c
@@ -703,6 +703,7 @@ void redisAsyncHandleTimeout(redisAsyncContext *ac) {
 
     if (!c->err) {
         __redisSetError(c, REDIS_ERR_TIMEOUT, "Timeout");
+        __redisAsyncCopyError(ac);
     }
 
     if (!(c->flags & REDIS_CONNECTED) && ac->onConnect) {


### PR DESCRIPTION
On async timeout, hiredis sets error to redis context, but not redis async context. This requires users to make an extra indirection to the redisContext struct, which is very confusing.