### PR TITLE
Various fixes and updates to the reply parsing implementation

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -235,6 +235,7 @@ static void *createDoubleObject(const redisReadTask *task, double value, char *s
      * decimal string conversion artifacts. */
     memcpy(r->str, str, len);
     r->str[len] = '\0';
+    r->len = len;
 
     if (task->parent) {
         parent = task->parent->obj;

--- a/hiredis.c
+++ b/hiredis.c
@@ -243,7 +243,8 @@ static void *createDoubleObject(const redisReadTask *task, double value, char *s
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY ||
                parent->type == REDIS_REPLY_MAP ||
-               parent->type == REDIS_REPLY_SET);
+               parent->type == REDIS_REPLY_SET ||
+               parent->type == REDIS_REPLY_PUSH);
         parent->element[task->idx] = r;
     }
     return r;
@@ -260,7 +261,8 @@ static void *createNilObject(const redisReadTask *task) {
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY ||
                parent->type == REDIS_REPLY_MAP ||
-               parent->type == REDIS_REPLY_SET);
+               parent->type == REDIS_REPLY_SET ||
+               parent->type == REDIS_REPLY_PUSH);
         parent->element[task->idx] = r;
     }
     return r;
@@ -279,7 +281,8 @@ static void *createBoolObject(const redisReadTask *task, int bval) {
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY ||
                parent->type == REDIS_REPLY_MAP ||
-               parent->type == REDIS_REPLY_SET);
+               parent->type == REDIS_REPLY_SET ||
+               parent->type == REDIS_REPLY_PUSH);
         parent->element[task->idx] = r;
     }
     return r;

--- a/hiredis.c
+++ b/hiredis.c
@@ -96,6 +96,8 @@ void freeReplyObject(void *reply) {
 
     switch(r->type) {
     case REDIS_REPLY_INTEGER:
+    case REDIS_REPLY_NIL:
+    case REDIS_REPLY_BOOL:
         break; /* Nothing to free */
     case REDIS_REPLY_ARRAY:
     case REDIS_REPLY_MAP:

--- a/hiredis.c
+++ b/hiredis.c
@@ -114,6 +114,7 @@ void freeReplyObject(void *reply) {
     case REDIS_REPLY_STRING:
     case REDIS_REPLY_DOUBLE:
     case REDIS_REPLY_VERB:
+    case REDIS_REPLY_BIGNUM:
         hi_free(r->str);
         break;
     }
@@ -131,7 +132,8 @@ static void *createStringObject(const redisReadTask *task, char *str, size_t len
     assert(task->type == REDIS_REPLY_ERROR  ||
            task->type == REDIS_REPLY_STATUS ||
            task->type == REDIS_REPLY_STRING ||
-           task->type == REDIS_REPLY_VERB);
+           task->type == REDIS_REPLY_VERB   ||
+           task->type == REDIS_REPLY_BIGNUM);
 
     /* Copy string value */
     if (task->type == REDIS_REPLY_VERB) {

--- a/hiredis.h
+++ b/hiredis.h
@@ -112,7 +112,8 @@ typedef struct redisReply {
     double dval; /* The double when type is REDIS_REPLY_DOUBLE */
     size_t len; /* Length of string */
     char *str; /* Used for REDIS_REPLY_ERROR, REDIS_REPLY_STRING
-                  REDIS_REPLY_VERB, and REDIS_REPLY_DOUBLE (in additional to dval). */
+                  REDIS_REPLY_VERB, REDIS_REPLY_DOUBLE (in additional to dval),
+                  and REDIS_REPLY_BIGNUM. */
     char vtype[4]; /* Used for REDIS_REPLY_VERB, contains the null
                       terminated 3 character content type, such as "txt". */
     size_t elements; /* number of elements, for REDIS_REPLY_ARRAY */

--- a/read.c
+++ b/read.c
@@ -331,7 +331,15 @@ static int processLineItem(redisReader *r) {
             else
                 obj = (void*)REDIS_REPLY_NIL;
         } else if (cur->type == REDIS_REPLY_BOOL) {
-            int bval = p[0] == 't' || p[0] == 'T';
+            int bval;
+
+            if (len != 1 || !strchr("tTfF", p[0])) {
+                __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                        "Bad bool value");
+                return REDIS_ERR;
+            }
+
+            bval = p[0] == 't' || p[0] == 'T';
             if (r->fn && r->fn->createBool)
                 obj = r->fn->createBool(cur,bval);
             else

--- a/read.c
+++ b/read.c
@@ -123,29 +123,22 @@ static char *readBytes(redisReader *r, unsigned int bytes) {
 
 /* Find pointer to \r\n. */
 static char *seekNewline(char *s, size_t len) {
-    int pos = 0;
+    char *_s = s, *ret;
     int _len = len-1;
 
-    /* Position should be < len-1 because the character at "pos" should be
-     * followed by a \n. Note that strchr cannot be used because it doesn't
-     * allow to search a limited length and the buffer that is being searched
-     * might not have a trailing NULL character. */
-    while (pos < _len) {
-        while(pos < _len && s[pos] != '\r') pos++;
-        if (pos==_len) {
-            /* Not found. */
-            return NULL;
-        } else {
-            if (s[pos+1] == '\n') {
-                /* Found. */
-                return s+pos;
-            } else {
-                /* Continue searching. */
-                pos++;
-            }
+    /* Exclude the last character from the searched length because the found
+     * '\r' should be followed by a '\n' */
+    while ((ret = memchr(_s, '\r', _len)) != NULL) {
+        if (ret[1] == '\n') {
+            /* Found. */
+            break;
         }
+        /* Continue searching. */
+        ret++;
+        _len -= ret - _s;
+        _s = ret;
     }
-    return NULL;
+    return ret;
 }
 
 /* Convert a string into a long long. Returns REDIS_OK if the string could be

--- a/read.c
+++ b/read.c
@@ -320,6 +320,12 @@ static int processLineItem(redisReader *r) {
                 obj = (void*)REDIS_REPLY_DOUBLE;
             }
         } else if (cur->type == REDIS_REPLY_NIL) {
+            if (len != 0) {
+                __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                        "Bad nil value");
+                return REDIS_ERR;
+            }
+
             if (r->fn && r->fn->createNil)
                 obj = r->fn->createNil(cur);
             else

--- a/read.c
+++ b/read.c
@@ -487,7 +487,6 @@ static int processAggregateItem(redisReader *r) {
     long long elements;
     int root = 0, len;
 
-    /* Set error for nested multi bulks with depth > 7 */
     if (r->ridx == r->tasks - 1) {
         if (redisReaderGrow(r) == REDIS_ERR)
             return REDIS_ERR;

--- a/read.c
+++ b/read.c
@@ -339,6 +339,13 @@ static int processLineItem(redisReader *r) {
                 obj = (void*)REDIS_REPLY_BOOL;
         } else {
             /* Type will be error or status. */
+            for (int i = 0; i < len; i++) {
+                if (p[i] == '\r' || p[i] == '\n') {
+                    __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                            "Bad simple string value");
+                    return REDIS_ERR;
+                }
+            }
             if (r->fn && r->fn->createString)
                 obj = r->fn->createString(cur,p,len);
             else

--- a/read.c
+++ b/read.c
@@ -123,21 +123,27 @@ static char *readBytes(redisReader *r, unsigned int bytes) {
 
 /* Find pointer to \r\n. */
 static char *seekNewline(char *s, size_t len) {
-    char *_s = s, *ret;
-    int _len = len-1;
+    char *ret;
 
-    /* Exclude the last character from the searched length because the found
-     * '\r' should be followed by a '\n' */
-    while ((ret = memchr(_s, '\r', _len)) != NULL) {
+    /* We cannot match with fewer than 2 bytes */
+    if (len < 2)
+        return NULL;
+
+    /* Search up to len - 1 characters */
+    len--;
+
+    /* Look for the \r */
+    while ((ret = memchr(s, '\r', len)) != NULL) {
         if (ret[1] == '\n') {
             /* Found. */
             break;
         }
         /* Continue searching. */
         ret++;
-        _len -= ret - _s;
-        _s = ret;
+        len -= ret - s;
+        s = ret;
     }
+
     return ret;
 }
 

--- a/read.c
+++ b/read.c
@@ -292,9 +292,9 @@ static int processLineItem(redisReader *r) {
                 memcpy(buf,p,len);
                 buf[len] = '\0';
 
-                if (strcasecmp(buf,"inf") == 0) {
+                if (len == 3 && strcasecmp(buf,"inf") == 0) {
                     d = INFINITY; /* Positive infinite. */
-                } else if (strcasecmp(buf,"-inf") == 0) {
+                } else if (len == 4 && strcasecmp(buf,"-inf") == 0) {
                     d = -INFINITY; /* Negative infinite. */
                 } else {
                     d = strtod((char*)buf,&eptr);
@@ -302,7 +302,7 @@ static int processLineItem(redisReader *r) {
                      * strtod() allows other variations on infinity, NaN,
                      * etc. We explicity handle our two allowed infinite cases
                      * above, so strtod() should only result in finite values. */
-                    if (buf[0] == '\0' || eptr[0] != '\0' || !isfinite(d)) {
+                    if (buf[0] == '\0' || eptr != &buf[len] || !isfinite(d)) {
                         __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
                                 "Bad double value");
                         return REDIS_ERR;

--- a/read.c
+++ b/read.c
@@ -299,13 +299,17 @@ static int processLineItem(redisReader *r) {
                 memcpy(buf,p,len);
                 buf[len] = '\0';
 
-                if (strcasecmp(buf,",inf") == 0) {
+                if (strcasecmp(buf,"inf") == 0) {
                     d = INFINITY; /* Positive infinite. */
-                } else if (strcasecmp(buf,",-inf") == 0) {
+                } else if (strcasecmp(buf,"-inf") == 0) {
                     d = -INFINITY; /* Negative infinite. */
                 } else {
                     d = strtod((char*)buf,&eptr);
-                    if (buf[0] == '\0' || eptr[0] != '\0' || isnan(d)) {
+                    /* RESP3 only allows "inf", "-inf", and finite values, while
+                     * strtod() allows other variations on infinity, NaN,
+                     * etc. We explicity handle our two allowed infinite cases
+                     * above, so strtod() should only result in finite values. */
+                    if (buf[0] == '\0' || eptr[0] != '\0' || !isfinite(d)) {
                         __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
                                 "Bad double value");
                         return REDIS_ERR;

--- a/test.c
+++ b/test.c
@@ -629,6 +629,35 @@ static void test_reply_reader(void) {
               strcasecmp(reader->errstr,"Bad nil value") == 0);
     freeReplyObject(reply);
     redisReaderFree(reader);
+
+    test("Can parse RESP3 bool (true): ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, "#t\r\n",4);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK &&
+              ((redisReply*)reply)->type == REDIS_REPLY_BOOL &&
+              ((redisReply*)reply)->integer);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
+
+    test("Can parse RESP3 bool (false): ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, "#f\r\n",4);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK &&
+              ((redisReply*)reply)->type == REDIS_REPLY_BOOL &&
+              !((redisReply*)reply)->integer);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
+
+    test("Set error on invalid RESP3 bool: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, "#foobar\r\n",9);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr,"Bad bool value") == 0);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
 }
 
 static void test_free_null(void) {

--- a/test.c
+++ b/test.c
@@ -611,6 +611,24 @@ static void test_reply_reader(void) {
               strcasecmp(reader->errstr,"Bad double value") == 0);
     freeReplyObject(reply);
     redisReaderFree(reader);
+
+    test("Can parse RESP3 nil: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, "_\r\n",3);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK &&
+              ((redisReply*)reply)->type == REDIS_REPLY_NIL);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
+
+    test("Set error on invalid RESP3 nil: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, "_nil\r\n",6);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr,"Bad nil value") == 0);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
 }
 
 static void test_free_null(void) {

--- a/test.c
+++ b/test.c
@@ -591,6 +591,26 @@ static void test_reply_reader(void) {
               strcmp(((redisReply*)reply)->str, "3.14159265358979323846") == 0);
     freeReplyObject(reply);
     redisReaderFree(reader);
+
+    test("Correctly parses RESP3 double INFINITY: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, ",inf\r\n",6);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK &&
+              ((redisReply*)reply)->type == REDIS_REPLY_DOUBLE &&
+              isinf(((redisReply*)reply)->dval) &&
+              ((redisReply*)reply)->dval > 0);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
+
+    test("Set error when RESP3 double is NaN: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, ",nan\r\n",6);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr,"Bad double value") == 0);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
 }
 
 static void test_free_null(void) {

--- a/test.c
+++ b/test.c
@@ -658,6 +658,26 @@ static void test_reply_reader(void) {
               strcasecmp(reader->errstr,"Bad bool value") == 0);
     freeReplyObject(reply);
     redisReaderFree(reader);
+
+    test("Can parse RESP3 map: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, "%2\r\n+first\r\n:123\r\n$6\r\nsecond\r\n#t\r\n",34);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK &&
+        ((redisReply*)reply)->type == REDIS_REPLY_MAP &&
+        ((redisReply*)reply)->elements == 4 &&
+        ((redisReply*)reply)->element[0]->type == REDIS_REPLY_STATUS &&
+        ((redisReply*)reply)->element[0]->len == 5 &&
+        !strcmp(((redisReply*)reply)->element[0]->str,"first") &&
+        ((redisReply*)reply)->element[1]->type == REDIS_REPLY_INTEGER &&
+        ((redisReply*)reply)->element[1]->integer == 123 &&
+        ((redisReply*)reply)->element[2]->type == REDIS_REPLY_STRING &&
+        ((redisReply*)reply)->element[2]->len == 6 &&
+        !strcmp(((redisReply*)reply)->element[2]->str,"second") &&
+        ((redisReply*)reply)->element[3]->type == REDIS_REPLY_BOOL &&
+        ((redisReply*)reply)->element[3]->integer);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
 }
 
 static void test_free_null(void) {

--- a/test.c
+++ b/test.c
@@ -678,6 +678,28 @@ static void test_reply_reader(void) {
         ((redisReply*)reply)->element[3]->integer);
     freeReplyObject(reply);
     redisReaderFree(reader);
+
+    test("Can parse RESP3 set: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, "~5\r\n+orange\r\n$5\r\napple\r\n#f\r\n:100\r\n:999\r\n",40);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK &&
+        ((redisReply*)reply)->type == REDIS_REPLY_SET &&
+        ((redisReply*)reply)->elements == 5 &&
+        ((redisReply*)reply)->element[0]->type == REDIS_REPLY_STATUS &&
+        ((redisReply*)reply)->element[0]->len == 6 &&
+        !strcmp(((redisReply*)reply)->element[0]->str,"orange") &&
+        ((redisReply*)reply)->element[1]->type == REDIS_REPLY_STRING &&
+        ((redisReply*)reply)->element[1]->len == 5 &&
+        !strcmp(((redisReply*)reply)->element[1]->str,"apple") &&
+        ((redisReply*)reply)->element[2]->type == REDIS_REPLY_BOOL &&
+        !((redisReply*)reply)->element[2]->integer &&
+        ((redisReply*)reply)->element[3]->type == REDIS_REPLY_INTEGER &&
+        ((redisReply*)reply)->element[3]->integer == 100 &&
+        ((redisReply*)reply)->element[4]->type == REDIS_REPLY_INTEGER &&
+        ((redisReply*)reply)->element[4]->integer == 999);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
 }
 
 static void test_free_null(void) {

--- a/test.c
+++ b/test.c
@@ -592,6 +592,15 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
+    test("Set error on invalid RESP3 double: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader, ",3.14159\000265358979323846\r\n",26);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr,"Bad double value") == 0);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
+
     test("Correctly parses RESP3 double INFINITY: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, ",inf\r\n",6);

--- a/test.c
+++ b/test.c
@@ -709,6 +709,17 @@ static void test_reply_reader(void) {
         ((redisReply*)reply)->element[4]->integer == 999);
     freeReplyObject(reply);
     redisReaderFree(reader);
+
+    test("Can parse RESP3 bignum: ");
+    reader = redisReaderCreate();
+    redisReaderFeed(reader,"(3492890328409238509324850943850943825024385\r\n",46);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK &&
+        ((redisReply*)reply)->type == REDIS_REPLY_BIGNUM &&
+        ((redisReply*)reply)->len == 43 &&
+        !strcmp(((redisReply*)reply)->str,"3492890328409238509324850943850943825024385"));
+    freeReplyObject(reply);
+    redisReaderFree(reader);
 }
 
 static void test_free_null(void) {


### PR DESCRIPTION
Summary of the salient changes:
- Fix the unset `len` field when creating RESP3 double objects
- Fix RESP3 double infinity parsing
- Add additional validations when parsing various reply types
- Fix the parent type assertions in certain default reply object creation callbacks
- Add various additional reader test cases
- Implement RESP3 BIGNUM support (it was listed in the README, but not actually implemented besides `#define REDIS_REPLY_BIGNUM`)
- Refactor `seekNewline()` to use `memchr()` (an existing comment described why `strchr()` could not be used, but `memchr()` has no such restrictions)

This can be split into multiple separate pull requests if need be, and some of the constituent commits can be squashed together if desired.

#### ADDITIONAL NOTES

The RESP3 attribute type is similarly described in the README but not actually implemented. I did not attempt an implementation yet due to its differing semantics from the other aggregate types that are *actually* part of relevant reply data. It may make sense to separate attributes from the other aggregate types in `redisReply`, and to continue parsing the next redis reply if a top-level attribute message is parsed.

There is also a currently-unimplemented RESP3 bulk error type, which should also be simple to implement, but there is a decision to be made as to whether or not it should be exposed as a distinct type from `REDIS_REPLY_ERROR` (similar to the distinction between `REDIS_REPLY_STATUS` and `REDIS_REPLY_STRING`).

These discussion are probably worth having in a separate issue.