### PR TITLE
Fix handling of NIL invalidation messages.

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -257,7 +257,8 @@ static void *createNilObject(const redisReadTask *task) {
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY ||
                parent->type == REDIS_REPLY_MAP ||
-               parent->type == REDIS_REPLY_SET);
+               parent->type == REDIS_REPLY_SET ||
+               parent->type == REDIS_REPLY_PUSH);
         parent->element[task->idx] = r;
     }
     return r;


### PR DESCRIPTION
When CLIENT TRACKING is enabled, Redis will send an invalidation message
with a NIL payload to all tracking clients after a FLUSHDB is executed.

We didn't account for REDIS_REPLY_PUSH being a valid parent object to a
NIL payload, and were failing an assertion.

Additionally, this commit adds a test for that situation.