### PR TITLE
Free SSL object when redisSSLConnect fails

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -351,6 +351,7 @@ static int redisSSLConnect(redisContext *c, SSL *ssl) {
     }
 
     hi_free(rssl);
+    SSL_free(ssl);
     return REDIS_ERR;
 }
 


### PR DESCRIPTION
# What Does This PR Do?

This set of changes removes a constant leak that occurs in `redisInitiateSSLWithContext`. Specifically, the issue is easily reproducible by trying to connect to an invalid IP address. 

1. The `SSL` object is created on line 383 in `redisInitiateSSLWithContext`:
    `SSL *ssl = SSL_new(redis_ssl_ctx->ssl_ctx);`

2. Which gets passed down to `redisSSLConnect`:
    `return redisSSLConnect(c, ssl)`

3. The `SSL_connect` function fails and the code falls through to to line 341 where the error string gets filled in:
    ```
    if (c->err == 0) {
        char err[512];
        if (rv == SSL_ERROR_SYSCALL)
            snprintf(err,sizeof(err)-1,"SSL_connect failed: %s",strerror(errno));
        else {
            unsigned long e = ERR_peek_last_error();
            snprintf(err,sizeof(err)-1,"SSL_connect failed: %s",
                    ERR_reason_error_string(e));
        }   
        __redisSetError(c, REDIS_ERR_IO, err);
    }
    ```

The function returns an error at this point, and the handle to `SSL` object is lost. Subsequent connections repeat this failure and start leaking large chunks of memory.

The fix itself is trivial - add the `SSL_free(ssl)` call before leaving the function.