### PR TITLE
Added fuzzer to integrate Hiredis into OSS-fuzz

### DIFF
--- a/fuzzing/format_command_fuzzer.c
+++ b/fuzzing/format_command_fuzzer.c
@@ -36,10 +36,10 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 	
-	if((int)size<3)
+	if(size<3)
 		return 0;
 	
-	char *new_str = (char *)malloc(size+1);
+	char *new_str = malloc(size+1);
 	if (new_str == NULL)
 		return 0;
 

--- a/fuzzing/format_command_fuzzer.c
+++ b/fuzzing/format_command_fuzzer.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2020, Pieter Noordhuis <pcnoordhuis at gmail dot com>
+ * Copyright (c) 2020, Matt Stancliff <matt at genges dot com>,
+ *                     Jan-Erik Rediger <janerik at fnordig dot com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+#include "hiredis.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	
+	if((int)size<3)
+		return 0;
+	
+	char *new_str = (char *)malloc(size+1);
+	if (new_str == NULL)
+		return 0;
+
+	char *cmd;
+	int len;
+	
+	memcpy(new_str, data, size);
+	new_str[size] = '\0';
+
+	len = redisFormatCommand(&cmd, new_str);
+	
+	if(cmd!=NULL)
+		hi_free(cmd);
+	free(new_str);
+	return 0;
+}


### PR DESCRIPTION
This PR adds a fuzzer that targets `redisFormatCommand`.

Fuzzing is a method of testing whereby pseudo-random data is passed to an application with the goal of finding bugs and vulnerabilities.

I have worked on running this fuzzer continuously through OSS-fuzz and have set up an integration on the OSS-fuzz side for this. If there is interest in fuzzing Hiredis continuously, all that is needed is for this fuzzer to be merged and at least one maintainers email address on the OSS-fuzz side. This will allow OSS-fuzz to run this fuzzer as well as all future fuzzers continuously, and in case bugs are found, maintainers get notified with an email containing a link to a detailed bug report. The service is free for open source projects and is offered with an implied expectation that bugs are fixed, so that the resources spent on fuzzing Hiredis go towards resolving bugs.