### PR TITLE
uv adapter: reduce number of uv_poll_start calls

### DIFF
--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -29,6 +29,10 @@ static void redisLibuvPoll(uv_poll_t* handle, int status, int events) {
 static void redisLibuvAddRead(void *privdata) {
   redisLibuvEvents* p = (redisLibuvEvents*)privdata;
 
+  if (p->events & UV_READABLE) {
+    return;
+  }
+
   p->events |= UV_READABLE;
 
   uv_poll_start(&p->handle, p->events, redisLibuvPoll);
@@ -50,6 +54,10 @@ static void redisLibuvDelRead(void *privdata) {
 
 static void redisLibuvAddWrite(void *privdata) {
   redisLibuvEvents* p = (redisLibuvEvents*)privdata;
+
+  if (p->events & UV_WRITABLE) {
+    return;
+  }
 
   p->events |= UV_WRITABLE;
 


### PR DESCRIPTION
Internally **uv_poll_start**  [iterates](https://github.com/libuv/libuv/blob/30ff5bf2161257921f3a3ce5655804f7cb282aa9/src/unix/posix-poll.c#L336) over all attached event handlers to update event mask. 
It's quite expensive operation if there many event handlers attached
to a loop

As _redisLibuvEvents.events_ is a copy of what libuv should see,
we can rely on it to avoid event mask updates.

For example, in [async.c#L662](https://github.com/redis/hiredis/blob/acc917548dcfd91e5d56387ed58b5f408cdb810a/async.c#L662) there is a high chance that fd is already being listened for writable events

Signed-off-by: Anton Tiurin <noxiouz@yandex.ru>