### PR TITLE
Fix crash bug during parse reply

### DIFF
--- a/read.c
+++ b/read.c
@@ -123,13 +123,17 @@ static char *readBytes(redisReader *r, unsigned int bytes) {
 
 /* Find pointer to \r\n. */
 static char *seekNewline(char *s, size_t len) {
-    int pos = 0;
-    int _len = len-1;
+    size_t _len, pos = 0;
+
+    if (len == 0) {
+        return NULL;
+    }
 
     /* Position should be < len-1 because the character at "pos" should be
      * followed by a \n. Note that strchr cannot be used because it doesn't
      * allow to search a limited length and the buffer that is being searched
      * might not have a trailing NULL character. */
+    _len = len-1;
     while (pos < _len) {
         while(pos < _len && s[pos] != '\r') pos++;
         if (pos==_len) {


### PR DESCRIPTION
**In the scenario of parsing certain strings, the parsing process will crash**

Crash occurs when parsing the string `*3\r\n$3\r\nSET\r\n$5\r\nhello\r\n$`, the reason is that in some scenarios, `r->pos` and `r->len` will be equal, leading to crash.

The related problem code is as follows:

```c
static int processBulkItem(redisReader *r) {
    redisReadTask *cur = r->task[r->ridx];
    void *obj = NULL;
    char *p, *s;
    long long len;
    unsigned long bytelen;
    int success = 0;

    p = r->buf+r->pos;
    s = seekNewline(p,r->len-r->pos);
    if (s != NULL) {
        p = r->buf+r->pos;
        bytelen = s-(r->buf+r->pos)+2; /* include \r\n */
        
       /* omit part of the code .... */
    }

    return REDIS_ERR;
}
```

- `_len` has the risk of overflow
- `len` may be 0

```c
/* Find pointer to \r\n. */
static char *seekNewline(char *s, size_t len) {
    int pos = 0;
    int _len = len-1;

    /* omit part of the code .... */
}

```