### PR TITLE
set default SSL verification path

### DIFF
--- a/hiredis_ssl.h
+++ b/hiredis_ssl.h
@@ -56,6 +56,7 @@ typedef enum {
     REDIS_SSL_CTX_CERT_KEY_REQUIRED,            /* Client cert and key must both be specified or skipped */
     REDIS_SSL_CTX_CA_CERT_LOAD_FAILED,          /* Failed to load CA Certificate or CA Path */
     REDIS_SSL_CTX_CLIENT_CERT_LOAD_FAILED,      /* Failed to load client certificate */
+    REDIS_SSL_CTX_CLIENT_DEFAULT_CERT_FAILED,   /* Failed to set client default certificate directory */
     REDIS_SSL_CTX_PRIVATE_KEY_LOAD_FAILED,      /* Failed to load private key */
     REDIS_SSL_CTX_OS_CERTSTORE_OPEN_FAILED,     /* Failed to open system certifcate store */
     REDIS_SSL_CTX_OS_CERT_ADD_FAILED            /* Failed to add CA certificates obtained from system to the SSL context */

--- a/ssl.c
+++ b/ssl.c
@@ -273,6 +273,11 @@ redisSSLContext *redisCreateSSLContext(const char *cacert_filename, const char *
             if (error) *error = REDIS_SSL_CTX_CA_CERT_LOAD_FAILED;
             goto error;
         }
+    } else {
+        if (!SSL_CTX_set_default_verify_paths(ctx->ssl_ctx)) {
+            if (error) *error = REDIS_SSL_CTX_CLIENT_DEFAULT_CERT_FAILED;
+            goto error;
+        }
     }
 
     if (cert_filename) {


### PR DESCRIPTION
Adding missing default verify path for client certificates.

Issue causing connection fail if certificate is not specified in connection settings (it's optional so it doesn't need to be specified).
Fixes https://github.com/redis/hiredis/issues/927 however issue is not skipping verification but setting default path.