### PR TITLE
Bugfix: Ignore timeout callback from a successful connect (fixes #945)

### DIFF
--- a/async.c
+++ b/async.c
@@ -690,9 +690,17 @@ void redisAsyncHandleTimeout(redisAsyncContext *ac) {
     redisContext *c = &(ac->c);
     redisCallback cb;
 
-    if ((c->flags & REDIS_CONNECTED) && ac->replies.head == NULL) {
-        /* Nothing to do - just an idle timeout */
-        return;
+    if ((c->flags & REDIS_CONNECTED)) {
+        if ( ac->replies.head == NULL) {
+            /* Nothing to do - just an idle timeout */
+            return;
+        }
+
+        if (!ac->c.command_timeout || 
+            (!ac->c.command_timeout->tv_sec && !ac->c.command_timeout->tv_usec)) {
+            /* A belated connect timeout arriving, ignore */
+            return;
+        }
     }
 
     if (!c->err) {


### PR DESCRIPTION
If `redisAsyncConnect` is done with a connect_timeout, and subsequently a redisAsyncCommand() happens but with no command_timeout, the connect timeout can still arrive, since it is never cancelled.  This fix prevents such a belated timeout from cancelling a command.