### PR TITLE
improve SSL leak fix redis/hiredis#896

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -351,7 +351,6 @@ static int redisSSLConnect(redisContext *c, SSL *ssl) {
     }
 
     hi_free(rssl);
-    SSL_free(ssl);
     return REDIS_ERR;
 }
 
@@ -393,7 +392,11 @@ int redisInitiateSSLWithContext(redisContext *c, redisSSLContext *redis_ssl_ctx)
         }
     }
 
-    return redisSSLConnect(c, ssl);
+    if (redisSSLConnect(c, ssl) != REDIS_OK) {
+        goto error;
+    }
+
+    return REDIS_OK;
 
 error:
     if (ssl)


### PR DESCRIPTION
improve SSL leak fix redis/hiredis#896

Free SSL object when redisSSLConnect fails but avoid doing that for
callers of redisInitiateSSL who are supposed to manager their own SSL
object.