### PR TITLE
add `static` to non-public functions, helped by -Wmissing-prototypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ if (MSVC)
         CONFIGURATIONS Debug RelWithDebInfo)
 endif()
 
+IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wmissing-prototypes -Wstrict-prototypes")
+ENDIF()
+
 # For NuGet packages
 INSTALL(FILES hiredis.targets
     DESTINATION build/native)

--- a/async.c
+++ b/async.c
@@ -44,6 +44,7 @@
 #include "dict.c"
 #include "sds.h"
 #include "win32.h"
+#include "private.h"
 
 #include "async_private.h"
 
@@ -51,10 +52,6 @@
 #undef assert
 #define assert(e) (void)(e)
 #endif
-
-/* Forward declarations of hiredis.c functions */
-int __redisAppendCommand(redisContext *c, const char *cmd, size_t len);
-void __redisSetError(redisContext *c, int type, const char *str);
 
 /* Functions managing dictionary of callbacks for pub/sub. */
 static unsigned int callbackHash(const void *key) {

--- a/hiredis.c
+++ b/hiredis.c
@@ -43,9 +43,7 @@
 #include "sds.h"
 #include "async.h"
 #include "win32.h"
-
-extern int redisContextUpdateConnectTimeout(redisContext *c, const struct timeval *timeout);
-extern int redisContextUpdateCommandTimeout(redisContext *c, const struct timeval *timeout);
+#include "private.h"
 
 static redisContextFuncs redisContextDefaultFuncs = {
     .free_privctx = NULL,

--- a/net.c
+++ b/net.c
@@ -46,9 +46,7 @@
 #include "sds.h"
 #include "sockcompat.h"
 #include "win32.h"
-
-/* Defined in hiredis.c */
-void __redisSetError(redisContext *c, int type, const char *str);
+#include "private.h"
 
 void redisNetClose(redisContext *c) {
     if (c && c->fd != REDIS_INVALID_FD) {

--- a/private.h
+++ b/private.h
@@ -1,0 +1,11 @@
+#ifndef __HIREDIS_INTERNAL_H
+#define __HIREDIS_INTERNAL_H
+
+#include "hiredis.h"
+
+int redisContextUpdateCommandTimeout(redisContext *c, const struct timeval *timeout);
+int redisContextUpdateConnectTimeout(redisContext *c, const struct timeval *timeout);
+void __redisSetError(redisContext *c, int type, const char *str);
+int __redisAppendCommand(redisContext *c, const char *cmd, size_t len);
+
+#endif

--- a/sds.c
+++ b/sds.c
@@ -428,7 +428,7 @@ sds sdscpy(sds s, const char *t) {
  * The function returns the length of the null-terminated string
  * representation stored at 's'. */
 #define SDS_LLSTR_SIZE 21
-int sdsll2str(char *s, long long value) {
+static int sdsll2str(char *s, long long value) {
     char *p, aux;
     unsigned long long v;
     size_t l;
@@ -460,7 +460,7 @@ int sdsll2str(char *s, long long value) {
 }
 
 /* Identical sdsll2str(), but for unsigned long long type. */
-int sdsull2str(char *s, unsigned long long v) {
+static int sdsull2str(char *s, unsigned long long v) {
     char *p, aux;
     size_t l;
 
@@ -896,7 +896,7 @@ sds sdscatrepr(sds s, const char *p, size_t len) {
 
 /* Helper function for sdssplitargs() that converts a hex digit into an
  * integer from 0 to 15 */
-int hex_digit_to_int(char c) {
+static int hex_digit_to_int(char c) {
     switch(c) {
     case '0': return 0;
     case '1': return 1;

--- a/test.c
+++ b/test.c
@@ -90,7 +90,7 @@ static long long usec(void) {
 
 /* Helper to extract Redis version information.  Aborts on any failure. */
 #define REDIS_VERSION_FIELD "redis_version:"
-void get_redis_version(redisContext *c, int *majorptr, int *minorptr) {
+static void get_redis_version(redisContext *c, int *majorptr, int *minorptr) {
     redisReply *reply;
     char *eptr, *s, *e;
     int major, minor;
@@ -825,7 +825,7 @@ static void test_blocking_connection_errors(void) {
 }
 
 /* Test push handler */
-void push_handler(void *privdata, void *r) {
+static void push_handler(void *privdata, void *r) {
     struct pushCounters *pcounts = privdata;
     redisReply *reply = r, *payload;
 
@@ -846,7 +846,7 @@ void push_handler(void *privdata, void *r) {
 }
 
 /* Dummy function just to test setting a callback with redisOptions */
-void push_handler_async(redisAsyncContext *ac, void *reply) {
+static void push_handler_async(redisAsyncContext *ac, void *reply) {
     (void)ac;
     (void)reply;
 }
@@ -911,7 +911,7 @@ static void test_resp3_push_handler(redisContext *c) {
     send_hello(c, 2);
 }
 
-redisOptions get_redis_tcp_options(struct config config) {
+static redisOptions get_redis_tcp_options(struct config config) {
     redisOptions options = {0};
     REDIS_OPTIONS_SET_TCP(&options, config.tcp.host, config.tcp.port);
     return options;
@@ -956,7 +956,7 @@ static void test_resp3_push_options(struct config config) {
     redisAsyncFree(ac);
 }
 
-void free_privdata(void *privdata) {
+static void free_privdata(void *privdata) {
     struct privdata *data = privdata;
     data->dtor_counter++;
 }
@@ -1213,7 +1213,7 @@ static void test_invalid_timeout_errors(struct config config) {
 
 /* Wrap malloc to abort on failure so OOM checks don't make the test logic
  * harder to follow. */
-void *hi_malloc_safe(size_t size) {
+static void *hi_malloc_safe(size_t size) {
     void *ptr = hi_malloc(size);
     if (ptr == NULL) {
         fprintf(stderr, "Error:  Out of memory\n");


### PR DESCRIPTION
Hi!

There seem unintentionally exposed functions, for example, `hex_digit_to_int`, so I've added `static` to them. I've also added some warnings to help this work, especially `-Wmissing-prototypes`. 

What do you think of it?