### PR TITLE
Fixed typo in CMakeLists.txt prevented SSL-test from running

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ PROJECT(hiredis)
 
 OPTION(ENABLE_SSL "Build hiredis_ssl for SSL support" OFF)
 OPTION(DISABLE_TESTS "If tests should be compiled or not" OFF)
-OPTION(ENABLE_SSL_TESTS, "Should we test SSL connections" OFF)
+OPTION(ENABLE_SSL_TESTS "Should we test SSL connections" OFF)
 
 MACRO(getVersionBit name)
   SET(VERSION_REGEX "^#define ${name} (.+)$")


### PR DESCRIPTION
Hi!
There was a typo in CMakeLists.txt: option for enabling ssl-test was named ```ENABLE_SSL_TESTS,```, note the comma at the end, while check for actual enabling some compile-time directives was ```IF(ENABLE_SSL_TEST)```, note no comma