### PR TITLE
Fix ProtocolError

### DIFF
--- a/net.c
+++ b/net.c
@@ -81,14 +81,6 @@ ssize_t redisNetRead(redisContext *c, char *buf, size_t bufcap) {
 
 ssize_t redisNetWrite(redisContext *c) {
     ssize_t nwritten = send(c->fd, c->obuf, sdslen(c->obuf), 0);
-    if (nwritten < 0) {
-        if ((errno == EWOULDBLOCK && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
-            /* Try again later */
-        } else {
-            __redisSetError(c, REDIS_ERR_IO, NULL);
-            return -1;
-        }
-    }
     return nwritten;
 }
 


### PR DESCRIPTION
This PR fixes an issue with incorrect behaviour of redisBufferWrite after merging SSL support.

The following logic was moved from redisBufferWrite to rawWrite in [commit](https://github.com/redis/hiredis/commit/0c1454490669f3c95e3c8b0ac6a83582d14e30e0#diff-b61215f4090069fa2ec48b946a1f19df25f63b1eb9e35d5bf71bd9128ae14498R830)
```
if ((errno == EAGAIN && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
    /* Try again later */
} else {
    __redisSetError(c, REDIS_ERR_IO, NULL);
    return -1;
}
```

The "Try again later" thing stopped working after that commit. This produces runtime errors in hiredis-rb after upgrading its hiredis to the latest version.

To reproduce the error:
1. git clone https://github.com/appcast-inc/hiredis-rb.git (my fork)
2. git checkout 66d0807b26b807012193fa5d08c9944d9d982f01 (undo the commit which fixes the error above)
3. bundle install && bundle exec rake compile
4. and finally, run several times bundle exec rake test

And you will get a runtime error!

Reach me out if you have any questions.