### PR TITLE
Added REDIS_NO_AUTO_FREE_REPLIES flag

### DIFF
--- a/async.c
+++ b/async.c
@@ -569,7 +569,9 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
 
         if (cb.fn != NULL) {
             __redisRunCallback(ac,&cb,reply);
-            c->reader->fn->freeObject(reply);
+            if (!(c->flags & REDIS_NO_AUTO_FREE_REPLIES)){
+              c->reader->fn->freeObject(reply);
+            }
 
             /* Proceed with free'ing when redisAsyncFree() was called. */
             if (c->flags & REDIS_FREEING) {

--- a/async.c
+++ b/async.c
@@ -570,7 +570,7 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
         if (cb.fn != NULL) {
             __redisRunCallback(ac,&cb,reply);
             if (!(c->flags & REDIS_NO_AUTO_FREE_REPLIES)){
-              c->reader->fn->freeObject(reply);
+                c->reader->fn->freeObject(reply);
             }
 
             /* Proceed with free'ing when redisAsyncFree() was called. */

--- a/hiredis.c
+++ b/hiredis.c
@@ -804,6 +804,9 @@ redisContext *redisConnectWithOptions(const redisOptions *options) {
     if (options->options & REDIS_OPT_NOAUTOFREE) {
         c->flags |= REDIS_NO_AUTO_FREE;
     }
+    if (options->options & REDIS_OPT_NOAUTOFREEREPLIES) {
+        c->flags |= REDIS_NO_AUTO_FREE_REPLIES;
+    }
 
     /* Set any user supplied RESP3 PUSH handler or use freeReplyObject
      * as a default unless specifically flagged that we don't want one. */

--- a/hiredis.h
+++ b/hiredis.h
@@ -86,10 +86,7 @@ typedef long long ssize_t;
  */
 #define REDIS_NO_AUTO_FREE 0x200
 
-/**
- * Flag that indicates the user does not want the context to
- * be automatically freed replies
- */
+/* Flag that indicates the user does not want replies to be automatically freed */
 #define REDIS_NO_AUTO_FREE_REPLIES 0x400
 
 #define REDIS_KEEPALIVE_INTERVAL 15 /* seconds */

--- a/hiredis.h
+++ b/hiredis.h
@@ -86,6 +86,12 @@ typedef long long ssize_t;
  */
 #define REDIS_NO_AUTO_FREE 0x200
 
+/**
+ * Flag that indicates the user does not want the context to
+ * be automatically freed replies
+ */
+#define REDIS_NO_AUTO_FREE_REPLIES 0x400
+
 #define REDIS_KEEPALIVE_INTERVAL 15 /* seconds */
 
 /* number of times we retry to connect in the case of EADDRNOTAVAIL and
@@ -152,6 +158,11 @@ struct redisSsl;
 
 /* Don't automatically intercept and free RESP3 PUSH replies. */
 #define REDIS_OPT_NO_PUSH_AUTOFREE 0x08
+
+/**
+ * Don't automatically free replies
+ */
+#define REDIS_OPT_NOAUTOFREEREPLIES 0x10
 
 /* In Unix systems a file descriptor is a regular signed int, with -1
  * representing an invalid descriptor. In Windows it is a SOCKET


### PR DESCRIPTION
The new flag can be set on the redisOptions struct and given to the async connection. If set, the new flag makes sure the replies given to the async callback will not be freed by hiredis. Instead, the reply ownership is given to the callback and it's the user's
responsibility to free it when he finished using it.