### PR TITLE
Corrections for event library adapters

### DIFF
--- a/adapters/libev.h
+++ b/adapters/libev.h
@@ -66,8 +66,9 @@ static void redisLibevWriteEvent(EV_P_ ev_io *watcher, int revents) {
 
 static void redisLibevAddRead(void *privdata) {
     redisLibevEvents *e = (redisLibevEvents*)privdata;
+#if EV_MULTIPLICITY
     struct ev_loop *loop = e->loop;
-    ((void)loop);
+#endif
     if (!e->reading) {
         e->reading = 1;
         ev_io_start(EV_A_ &e->rev);
@@ -76,8 +77,9 @@ static void redisLibevAddRead(void *privdata) {
 
 static void redisLibevDelRead(void *privdata) {
     redisLibevEvents *e = (redisLibevEvents*)privdata;
+#if EV_MULTIPLICITY
     struct ev_loop *loop = e->loop;
-    ((void)loop);
+#endif
     if (e->reading) {
         e->reading = 0;
         ev_io_stop(EV_A_ &e->rev);
@@ -86,8 +88,9 @@ static void redisLibevDelRead(void *privdata) {
 
 static void redisLibevAddWrite(void *privdata) {
     redisLibevEvents *e = (redisLibevEvents*)privdata;
+#if EV_MULTIPLICITY
     struct ev_loop *loop = e->loop;
-    ((void)loop);
+#endif
     if (!e->writing) {
         e->writing = 1;
         ev_io_start(EV_A_ &e->wev);
@@ -96,8 +99,9 @@ static void redisLibevAddWrite(void *privdata) {
 
 static void redisLibevDelWrite(void *privdata) {
     redisLibevEvents *e = (redisLibevEvents*)privdata;
+#if EV_MULTIPLICITY
     struct ev_loop *loop = e->loop;
-    ((void)loop);
+#endif
     if (e->writing) {
         e->writing = 0;
         ev_io_stop(EV_A_ &e->wev);
@@ -106,8 +110,9 @@ static void redisLibevDelWrite(void *privdata) {
 
 static void redisLibevStopTimer(void *privdata) {
     redisLibevEvents *e = (redisLibevEvents*)privdata;
+#if EV_MULTIPLICITY
     struct ev_loop *loop = e->loop;
-    ((void)loop);
+#endif
     ev_timer_stop(EV_A_ &e->timer);
 }
 
@@ -120,6 +125,9 @@ static void redisLibevCleanup(void *privdata) {
 }
 
 static void redisLibevTimeout(EV_P_ ev_timer *timer, int revents) {
+#if EV_MULTIPLICITY
+    ((void)EV_A);
+#endif
     ((void)revents);
     redisLibevEvents *e = (redisLibevEvents*)timer->data;
     redisAsyncHandleTimeout(e->context);
@@ -127,8 +135,9 @@ static void redisLibevTimeout(EV_P_ ev_timer *timer, int revents) {
 
 static void redisLibevSetTimeout(void *privdata, struct timeval tv) {
     redisLibevEvents *e = (redisLibevEvents*)privdata;
+#if EV_MULTIPLICITY
     struct ev_loop *loop = e->loop;
-    ((void)loop);
+#endif
 
     if (!ev_is_active(&e->timer)) {
         ev_init(&e->timer, redisLibevTimeout);

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,7 +21,7 @@ ENDIF()
 
 FIND_PATH(LIBEVENT event.h)
 if (LIBEVENT)
-    ADD_EXECUTABLE(example-libevent example-libevent)
+    ADD_EXECUTABLE(example-libevent example-libevent.c)
     TARGET_LINK_LIBRARIES(example-libevent hiredis event)
 ENDIF()
 


### PR DESCRIPTION
Fix the unused parameter warning in the `libev` adapter.
This is triggered when a user is building the adapter with Clang and having e.g `-Wextra -Werror` warnings enabled,
but it seems to work fine with GCC. Verified for both `-DEV_MULTIPLICITY=0` and `-DEV_MULTIPLICITY=1`


Also correcting a CMake warning when building the example for `libevent`.

Details:
```
CC=clang make CFLAGS="-Wunused-parameter -Werror" clean examples

./adapters/libev.h:122:31: error: unused parameter 'loop' [-Werror,-Wunused-parameter]
in
static void redisLibevTimeout(EV_P_ ev_timer *timer, int revents) {
$ clang --version
clang version 10.0.0-4ubuntu1
```
```
cmake -DENABLE_EXAMPLES=ON ..
CMake Warning (dev) at examples/CMakeLists.txt:24 (ADD_EXECUTABLE):
  Policy CMP0115 is not set: Source file extensions must be explicit. 
```