### PR TITLE
Removed unused import

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -44,7 +44,6 @@
 #endif
 
 #include <openssl/ssl.h>
-#include <openssl/err.h>
 
 #include "win32.h"
 #include "async_private.h"


### PR DESCRIPTION
This line causes a build breakage in environments that only expose some (public?) OpenSSL header files.

I'm not an expert in the area. Just noticed it and submitting a simple fix for it.
