### PR TITLE
Hiredis: Advanced async-handling

### DIFF
--- a/async.c
+++ b/async.c
@@ -52,36 +52,35 @@
 #define assert(e) (void)(e)
 #endif
 
-/* Forward declarations of hiredis.c functions */
-int __redisAppendCommand(redisContext *c, const char *cmd, size_t len);
-void __redisSetError(redisContext *c, int type, const char *str);
+/* Forward declaration of function in hiredis.c */
+void __redisSetError(redisContext *, int, const char *, ...);
+int __redisAppendCommand(redisContext *, const char *, size_t);
 
 /* Functions managing dictionary of callbacks for pub/sub. */
 static unsigned int callbackHash(const void *key) {
-    return dictGenHashFunction((const unsigned char *)key,
-                               sdslen((const sds)key));
+    return dictGenHashFunction(key, sdslen((const sds) key));
 }
 
 static void *callbackValDup(void *privdata, const void *src) {
-    ((void) privdata);
     redisCallback *dup;
+    ((void) privdata);
 
-    dup = hi_malloc(sizeof(*dup));
-    if (dup == NULL)
-        return NULL;
+    if (NULL != (dup = hi_malloc(sizeof(*dup))))
+        memcpy(dup, src, sizeof(*dup));
 
-    memcpy(dup,src,sizeof(*dup));
     return dup;
 }
 
 static int callbackKeyCompare(void *privdata, const void *key1, const void *key2) {
-    int l1, l2;
+    size_t l1, l2;
     ((void) privdata);
 
     l1 = sdslen((const sds)key1);
     l2 = sdslen((const sds)key2);
+
     if (l1 != l2) return 0;
-    return memcmp(key1,key2,l1) == 0;
+
+    return  0 == memcmp(key1, key2, l1);
 }
 
 static void callbackKeyDestructor(void *privdata, void *key) {
@@ -107,16 +106,10 @@ static redisAsyncContext *redisAsyncInitialize(redisContext *c) {
     redisAsyncContext *ac;
     dict *channels = NULL, *patterns = NULL;
 
-    channels = dictCreate(&callbackDict,NULL);
-    if (channels == NULL)
-        goto oom;
-
-    patterns = dictCreate(&callbackDict,NULL);
-    if (patterns == NULL)
-        goto oom;
-
-    ac = hi_realloc(c,sizeof(redisAsyncContext));
-    if (ac == NULL)
+    /* Allocate memory at the start - OOM on failure */
+    if (NULL == (channels = dictCreate(&callbackDict,NULL)) ||
+        NULL == (patterns = dictCreate(&callbackDict,NULL)) ||
+        NULL == (ac = hi_realloc(c,sizeof(redisAsyncContext))))
         goto oom;
 
     c = &(ac->c);
@@ -153,6 +146,7 @@ static redisAsyncContext *redisAsyncInitialize(redisContext *c) {
 oom:
     if (channels) dictRelease(channels);
     if (patterns) dictRelease(patterns);
+    /* NOTE: no need to release `ac` as it's last to cause OOM */
     return NULL;
 }
 
@@ -165,6 +159,16 @@ static void __redisAsyncCopyError(redisAsyncContext *ac) {
     redisContext *c = &(ac->c);
     ac->err = c->err;
     ac->errstr = c->errstr;
+}
+
+static void __redisAsyncSetError(redisAsyncContext *ctx, int err_type, const char *msg) {
+    /* Set the errstr if not already set */
+    if (NULL == ctx->errstr) {
+        ctx->errstr = ctx->c.errstr;
+    }
+
+    ctx->err = err_type;
+    __redisSetError(&ctx->c, err_type, msg);
 }
 
 redisAsyncContext *redisAsyncConnectWithOptions(const redisOptions *options) {
@@ -305,7 +309,7 @@ static void __redisRunPushCallback(redisAsyncContext *ac, redisReply *reply) {
 /* Helper function to free the context. */
 static void __redisAsyncFree(redisAsyncContext *ac) {
     redisContext *c = &(ac->c);
-    redisCallback cb;
+    redisCallback cb, *pcb;
     dictIterator it;
     dictEntry *de;
 
@@ -317,22 +321,20 @@ static void __redisAsyncFree(redisAsyncContext *ac) {
     while (__redisShiftCallback(&ac->sub.invalid,&cb) == REDIS_OK)
         __redisRunCallback(ac,&cb,NULL);
 
-    /* Run subscription callbacks with NULL reply */
-    if (ac->sub.channels) {
-        dictInitIterator(&it,ac->sub.channels);
-        while ((de = dictNext(&it)) != NULL)
-            __redisRunCallback(ac,dictGetEntryVal(de),NULL);
+    #define RUN_SUB_CALLBACKS(cb_dict) \
+        if (cb_dict) { \
+            dictInitIterator(&it,cb_dict); \
+            while (NULL != (de = dictNext(&it))) \
+                pcb = dictGetEntryVal(de); \
+                if (pcb) __redisRunCallback(ac,pcb,NULL); \
+            dictRelease(cb_dict); \
+        }
 
-        dictRelease(ac->sub.channels);
-    }
+    /* Run subscription callbacks (channels & patterns) with NULL reply */
+    RUN_SUB_CALLBACKS(ac->sub.channels)
+    RUN_SUB_CALLBACKS(ac->sub.patterns)
 
-    if (ac->sub.patterns) {
-        dictInitIterator(&it,ac->sub.patterns);
-        while ((de = dictNext(&it)) != NULL)
-            __redisRunCallback(ac,dictGetEntryVal(de),NULL);
-
-        dictRelease(ac->sub.patterns);
-    }
+    #undef RUN_SUB_CALLBACKS
 
     /* Signal event lib to clean up */
     _EL_CLEANUP(ac);
@@ -441,6 +443,8 @@ static int __redisGetSubscribeCallback(redisAsyncContext *ac, redisReply *reply,
         de = dictFind(callbacks,sname);
         if (de != NULL) {
             cb = dictGetEntryVal(de);
+            if (cb == NULL)
+                goto oom;
 
             /* If this is an subscribe reply decrease pending counter. */
             if (strcasecmp(stype+pvariant,"subscribe") == 0) {
@@ -472,6 +476,7 @@ static int __redisGetSubscribeCallback(redisAsyncContext *ac, redisReply *reply,
     }
     return REDIS_OK;
 oom:
+    sdsfree(sname);
     __redisSetError(&(ac->c), REDIS_ERR_OOM, "Out of memory");
     return REDIS_ERR;
 }
@@ -707,8 +712,7 @@ void redisAsyncHandleTimeout(redisAsyncContext *ac) {
     }
 
     if (!c->err) {
-        __redisSetError(c, REDIS_ERR_TIMEOUT, "Timeout");
-        __redisAsyncCopyError(ac);
+        __redisAsyncSetError(ac, REDIS_ERR_TIMEOUT, "Timeout");
     }
 
     if (!(c->flags & REDIS_CONNECTED) && ac->onConnect) {
@@ -735,17 +739,17 @@ static const char *nextArgument(const char *start, const char **str, size_t *len
         if (p == NULL) return NULL;
     }
 
-    *len = (int)strtol(p+1,NULL,10);
+    *len = (size_t) strtoull(p+1,NULL,10);
     p = strchr(p,'\r');
     assert(p);
     *str = p+2;
     return p+2+(*len)+2;
 }
 
-/* Helper function for the redisAsyncCommand* family of functions. Writes a
+/* Helper function for the redisAsyncAppend* family of functions. Writes a
  * formatted command to the output buffer and registers the provided callback
  * function with the context. */
-static int __redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *cmd, size_t len) {
+static int __redisAsyncAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *cmd, size_t len) {
     redisContext *c = &(ac->c);
     redisCallback cb;
     struct dict *cbdict;
@@ -767,21 +771,38 @@ static int __redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void 
     cb.pending_subs = 1;
 
     /* Find out which command will be appended. */
-    p = nextArgument(cmd,&cstr,&clen);
-    assert(p != NULL);
+    if (NULL == (p = nextArgument(cmd,&cstr,&clen))) {
+        __redisAsyncSetError(ac, REDIS_ERR_PROTOCOL, "Invalid command format");
+        return REDIS_ERR;
+    }
+
     hasnext = (p[0] == '$');
     pvariant = (tolower(cstr[0]) == 'p') ? 1 : 0;
     cstr += pvariant;
     clen -= pvariant;
 
+    /* NOTICE:
+     *  Further non thread-safe actions [ we append to buffer before pushing having proper callback ]
+     *  Since hiredis is already not thread-safe let's just append first to check for OOM errors */
+
+    /* Make sure we can append command before making it's callback - Delegate error */
+    if (REDIS_OK != (ret = __redisAppendCommand(c,cmd,len))) return ret;
+
+#define PUSH_CALLBACK(cb_list) \
+    if (REDIS_OK != (ret = __redisPushCallback(&ac->cb_list, &cb))) { \
+        __redisAsyncSetError(ac, ret, "PushCallback failure"); \
+        goto oom_error; \
+    }
+
     if (hasnext && strncasecmp(cstr,"subscribe\r\n",11) == 0) {
         c->flags |= REDIS_SUBSCRIBED;
 
         /* Add every channel/pattern to the list of subscription callbacks. */
-        while ((p = nextArgument(p,&astr,&alen)) != NULL) {
-            sname = sdsnewlen(astr,alen);
-            if (sname == NULL)
-                goto oom;
+        while (NULL != (p = nextArgument(p,&astr,&alen))) {
+            if (NULL == (sname = sdsnewlen(astr,alen))) {
+                __redisAsyncSetError(ac, REDIS_ERR_OOM, "Out of memory");
+                goto oom_error;
+            }
 
             if (pvariant)
                 cbdict = ac->sub.patterns;
@@ -792,6 +813,9 @@ static int __redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void 
 
             if (de != NULL) {
                 existcb = dictGetEntryVal(de);
+                if (existcb == NULL)
+                    goto oom_error;
+
                 cb.pending_subs = existcb->pending_subs + 1;
             }
 
@@ -807,33 +831,105 @@ static int __redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void 
         /* (P)UNSUBSCRIBE does not have its own response: every channel or
          * pattern that is unsubscribed will receive a message. This means we
          * should not append a callback function for this command. */
-    } else if (strncasecmp(cstr,"monitor\r\n",9) == 0) {
+    } else if(strncasecmp(cstr,"monitor\r\n",9) == 0) {
         /* Set monitor flag and push callback */
         c->flags |= REDIS_MONITORING;
-        if (__redisPushCallback(&ac->replies,&cb) != REDIS_OK)
-            goto oom;
+        PUSH_CALLBACK(replies)
     } else {
         if (c->flags & REDIS_SUBSCRIBED) {
             /* This will likely result in an error reply, but it needs to be
              * received and passed to the callback. */
-            if (__redisPushCallback(&ac->sub.invalid,&cb) != REDIS_OK)
-                goto oom;
+            PUSH_CALLBACK(sub.invalid)
         } else {
-            if (__redisPushCallback(&ac->replies,&cb) != REDIS_OK)
-                goto oom;
+            PUSH_CALLBACK(replies)
         }
     }
-
-    __redisAppendCommand(c,cmd,len);
-
-    /* Always schedule a write when the write buffer is non-empty */
-    _EL_ADD_WRITE(ac);
+#undef PUSH_CALLBACK
 
     return REDIS_OK;
-oom:
-    __redisSetError(&(ac->c), REDIS_ERR_OOM, "Out of memory");
-    __redisAsyncCopyError(ac);
+
+oom_error:
+    /* Rollback the obuf data */
+    clen = sdslen(c->obuf) - len;
+    sdssetlen(c->obuf, clen);
+    c->obuf[clen] = '\0';
+
+    /* Free unused obuf space */
+    c->obuf = sdsRemoveFreeSpace(c->obuf);
+
     return REDIS_ERR;
+}
+
+int redisvAsyncAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, va_list ap) {
+    char *cmd;
+    int len;
+    int status;
+    len = redisvFormatCommand(&cmd,format,ap);
+
+    /* We don't want to pass -1 or -2 to future functions as a length. */
+    if (-1 == len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OOM,"Out of memory");
+        return REDIS_ERR;
+    } else if (-2 == len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OTHER,"Invalid format string");
+        return REDIS_ERR;
+    } else if (0 > len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OTHER,"Unknown format error");
+        return REDIS_ERR;
+    }
+
+    status = __redisAsyncAppend(ac, fn, privdata, cmd, (size_t)len);
+    free(cmd);
+    return status;
+}
+
+int redisAsyncAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...) {
+    va_list ap;
+    int status;
+    va_start(ap,format);
+    status = redisvAsyncCommand(ac,fn,privdata,format,ap);
+    va_end(ap);
+    return status;
+}
+
+int redisAsyncAppendArgv(   redisAsyncContext *ac,
+                            redisCallbackFn *fn, void *privdata,
+                            int argc, const char **argv, const size_t *argvlen) {
+    sds cmd;
+    int len;
+    int status;
+    len = redisFormatSdsCommandArgv(&cmd, argc, argv, argvlen);
+
+    if (-1 == len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OOM,"Out of memory");
+        return REDIS_ERR;
+    } else if (0 > len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OTHER,"Unknown format error");
+        return REDIS_ERR;
+    }
+
+    status = __redisAsyncAppend(ac, fn, privdata, cmd, (size_t)len);
+    sdsfree(cmd);
+    return status;
+}
+
+int redisAsyncFormattedAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *cmd, size_t len) {
+    int status = __redisAsyncAppend(ac,fn,privdata,cmd,len);
+    return status;
+}
+
+/* Helper function for the redisAsyncCommand* family of functions. Writes a
+ * formatted command to the output buffer and registers the provided callback
+ * function with the context and triggers the scheduler 'ADD_WRITE' event. */
+static inline int __redisAsyncCommand(  redisAsyncContext *ac, redisCallbackFn *fn,
+                                        void *privdata, const char *cmd, size_t len) {
+    int ret = __redisAsyncAppend(ac, fn, privdata, cmd, len);
+    if (REDIS_OK == ret) {
+        /* Always schedule a write when the write buffer is non-empty */
+        _EL_ADD_WRITE(ac);
+    }
+
+    return ret;
 }
 
 int redisvAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, va_list ap) {
@@ -843,10 +939,18 @@ int redisvAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdat
     len = redisvFormatCommand(&cmd,format,ap);
 
     /* We don't want to pass -1 or -2 to future functions as a length. */
-    if (len < 0)
+    if (-1 == len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OOM,"Out of memory");
         return REDIS_ERR;
+    } else if (-2 == len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OTHER,"Invalid format string");
+        return REDIS_ERR;
+    } else if (0 > len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OTHER,"Unknown format error");
+        return REDIS_ERR;
+    }
 
-    status = __redisAsyncCommand(ac,fn,privdata,cmd,len);
+    status = __redisAsyncCommand(ac, fn, privdata, cmd, (size_t)len);
     hi_free(cmd);
     return status;
 }
@@ -865,9 +969,16 @@ int redisAsyncCommandArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *priv
     int len;
     int status;
     len = redisFormatSdsCommandArgv(&cmd,argc,argv,argvlen);
-    if (len < 0)
+
+    if (-1 == len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OOM,"Out of memory");
         return REDIS_ERR;
-    status = __redisAsyncCommand(ac,fn,privdata,cmd,len);
+    } else if (0 > len) {
+        __redisAsyncSetError(ac,REDIS_ERR_OTHER,"Unknown format error");
+        return REDIS_ERR;
+    }
+
+    status = __redisAsyncCommand(ac, fn, privdata, cmd, (size_t)len);
     sdsfree(cmd);
     return status;
 }
@@ -887,8 +998,7 @@ int redisAsyncSetTimeout(redisAsyncContext *ac, struct timeval tv) {
     if (!ac->c.command_timeout) {
         ac->c.command_timeout = hi_calloc(1, sizeof(tv));
         if (ac->c.command_timeout == NULL) {
-            __redisSetError(&ac->c, REDIS_ERR_OOM, "Out of memory");
-            __redisAsyncCopyError(ac);
+            __redisAsyncSetError(ac, REDIS_ERR_OOM, "Out of memory");
             return REDIS_ERR;
         }
     }

--- a/async.h
+++ b/async.h
@@ -133,8 +133,13 @@ void redisAsyncHandleTimeout(redisAsyncContext *ac);
 void redisAsyncRead(redisAsyncContext *ac);
 void redisAsyncWrite(redisAsyncContext *ac);
 
-/* Command functions for an async context. Write the command to the
- * output buffer and register the provided callback. */
+/* Append functions for an async context. Write the command to the output buffer and register the provided callback. */
+int redisvAsyncAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, va_list ap);
+int redisAsyncAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...);
+int redisAsyncAppendArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, int argc, const char **argv, const size_t *argvlen);
+int redisAsyncFormattedAppend(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *cmd, size_t len);
+
+/* Command functions for an async context. Append the command and trigger WRITE-EVENT */
 int redisvAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, va_list ap);
 int redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, const char *format, ...);
 int redisAsyncCommandArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, int argc, const char **argv, const size_t *argvlen);

--- a/dict.c
+++ b/dict.c
@@ -51,7 +51,7 @@ static int _dictInit(dict *ht, dictType *type, void *privDataPtr);
 
 /* Generic hash function (a popular one from Bernstein).
  * I tested a few and this was the best. */
-static unsigned int dictGenHashFunction(const unsigned char *buf, int len) {
+static unsigned int dictGenHashFunction(const unsigned char *buf, size_t len) {
     unsigned int hash = 5381;
 
     while (len--)

--- a/dict.h
+++ b/dict.h
@@ -111,7 +111,7 @@ typedef struct dictIterator {
 #define dictSize(ht) ((ht)->used)
 
 /* API */
-static unsigned int dictGenHashFunction(const unsigned char *buf, int len);
+static unsigned int dictGenHashFunction(const unsigned char *buf, size_t len);
 static dict *dictCreate(dictType *type, void *privDataPtr);
 static int dictExpand(dict *ht, unsigned long size);
 static int dictAdd(dict *ht, void *key, void *val);


### PR DESCRIPTION
+ hiredis.c: Convert redisSetError to take format and va_args
+ dict.*   : Fixed generic hash function -> cannot really take signed number
+ async.*  : Valdup function now handles OOM properly
             KeyCompare function uses proper sized integers
             nextArgument - change to use proper str-int conversion function
             Added redisAsyncAppend* function family to support buffer
                                                 optimizations in async-mode
             Added proper error handling on OOM errors [inc buffer rollback]

Review fixes

+ hiredis.c : Reverted back to memcpy(), will test *printf in different time
+ aysnc.c   : Minor changes for better readability

Handle unlikely/pathological OOM conditon cleanly.

More OOM checks