### PR TITLE
Fix hiredis blocking indefinitely despite timeout being set (#593)

### DIFF
--- a/net.c
+++ b/net.c
@@ -50,6 +50,8 @@
 /* Defined in hiredis.c */
 void __redisSetError(redisContext *c, int type, const char *str);
 
+int redisContextUpdateCommandTimeout(redisContext *c, const struct timeval *timeout);
+
 void redisNetClose(redisContext *c) {
     if (c && c->fd != REDIS_INVALID_FD) {
         close(c->fd);
@@ -317,6 +319,10 @@ int redisContextSetTimeout(redisContext *c, const struct timeval tv) {
     const void *to_ptr = &tv;
     size_t to_sz = sizeof(tv);
 
+    if (redisContextUpdateCommandTimeout(c, &tv) != REDIS_OK) {
+        __redisSetError(c, REDIS_ERR_OOM, "Out of memory");
+        return REDIS_ERR;
+    }
     if (setsockopt(c->fd,SOL_SOCKET,SO_RCVTIMEO,to_ptr,to_sz) == -1) {
         __redisSetErrorFromErrno(c,REDIS_ERR_IO,"setsockopt(SO_RCVTIMEO)");
         return REDIS_ERR;

--- a/test.c
+++ b/test.c
@@ -1107,7 +1107,13 @@ static void test_blocking_connection_timeouts(struct config config) {
     test("Does not return a reply when the command times out: ");
     if (detect_debug_sleep(c)) {
         redisAppendFormattedCommand(c, sleep_cmd, strlen(sleep_cmd));
+
+        // flush connection buffer without waiting for the reply
         s = c->funcs->write(c);
+        assert(s == (ssize_t)sdslen(c->obuf));
+        sdsfree(c->obuf);
+        c->obuf = sdsempty();
+
         tv.tv_sec = 0;
         tv.tv_usec = 10000;
         redisSetTimeout(c, tv);
@@ -1120,6 +1126,9 @@ static void test_blocking_connection_timeouts(struct config config) {
                   strcmp(c->errstr, "recv timeout") == 0);
 #endif
         freeReplyObject(reply);
+
+        // wait for the DEBUG SLEEP to complete so that Redis server is unblocked for the following tests
+        sleep(3);
     } else {
         test_skipped();
     }


### PR DESCRIPTION
Currently, `redisSetTimeout` function does not update `command_timeout` field in the context.
The following call to `redisReconnect` then resets the socket timeout to infinity.
This is probably the root cause of the issues (#593), (#718), (#263), (#517).

This PR fixes the bug and also fixes the corresponding test, which had two issues:
1. DEBUG SLEEP 3 was sent twice because manual `c->funcs->write` did not flush the connection buffer
2. DEBUG SLEEP 3 in one test affected the following test