### PR TITLE
Maintain ABI compatibility with 1.0.0

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -48,7 +48,7 @@ typedef long long ssize_t;
 #define HIREDIS_MAJOR 1
 #define HIREDIS_MINOR 0
 #define HIREDIS_PATCH 2
-#define HIREDIS_SONAME 1.0.2-dev
+#define HIREDIS_SONAME 1.0.0
 
 /* Connection type can be blocking or non-blocking and is set in the
  * least significant bit of the flags field in redisContext. */


### PR DESCRIPTION
The fix for CVE-2021-32765 didn't break the ABI, therefore the SONAME can remain at 1.0.0.

Fixes #990 