### PR TITLE
Minor refactor of CVE-2021-32765 fix.

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -68,6 +68,10 @@ void *hi_malloc(size_t size) {
 }
 
 void *hi_calloc(size_t nmemb, size_t size) {
+    /* Overflow check as the user can specify any arbitrary allocator */
+    if (SIZE_MAX / size < nmemb)
+        return NULL;
+
     return hiredisAllocFns.callocFn(nmemb, size);
 }
 

--- a/alloc.h
+++ b/alloc.h
@@ -32,6 +32,7 @@
 #define HIREDIS_ALLOC_H
 
 #include <stddef.h> /* for size_t */
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +60,10 @@ static inline void *hi_malloc(size_t size) {
 }
 
 static inline void *hi_calloc(size_t nmemb, size_t size) {
+    /* Overflow check as the user can specify any arbitrary allocator */
+    if (SIZE_MAX / size < nmemb)
+        return NULL;
+
     return hiredisAllocFns.callocFn(nmemb, size);
 }
 

--- a/hiredis.c
+++ b/hiredis.c
@@ -178,7 +178,6 @@ static void *createArrayObject(const redisReadTask *task, size_t elements) {
         return NULL;
 
     if (elements > 0) {
-        if (SIZE_MAX / sizeof(redisReply*) < elements) return NULL;  /* Don't overflow */
         r->element = hi_calloc(elements,sizeof(redisReply*));
         if (r->element == NULL) {
             freeReplyObject(r);


### PR DESCRIPTION
Since `hi_calloc` is a wrapper that calls the configured `calloc` function,
we can perform this overflow check there, to protect any `hi_calloc` call.

Previous commit: 76a7b10005c70babee357a7d0f2becf28ec7ed1e

Related vuln ID: CVE-2021-32765
[Full Details](https://github.com/redis/hiredis/security/advisories/GHSA-hfm9-39pp-55p2)

@yossigo It was pointed out to me that we could incorporate this check within our `hi_calloc` wrapper itself.  Let me know if if you see any issues with the change.