### PR TITLE
CMake wants language settings in GNUInstallDirs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.4.0)
+
+PROJECT(hiredis C)
+
 INCLUDE(GNUInstallDirs)
-PROJECT(hiredis)
 
 OPTION(ENABLE_SSL "Build hiredis_ssl for SSL support" OFF)
 OPTION(DISABLE_TESTS "If tests should be compiled or not" OFF)


### PR DESCRIPTION
```
CMake Warning (dev) at /usr/local/share/cmake-3.21/Modules/GNUInstallDirs.cmake:236 (message):
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  CMakeLists.txt:2 (INCLUDE)
This warning is for project developers.  Use -Wno-dev to suppress it.
```