### PR TITLE
Switch to GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: Build and test
+on: push
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.GITHUB_REPOSITORY }}
+          ref: ${{ env.GITHUB_HEAD_REF }}
+
+      - name: Install redis-server
+        run: |
+          sudo add-apt-repository -y ppa:chris-lea/redis-server
+          sudo apt-get update
+          sudo apt-get install -y redis-server
+
+      - name: Build hiredis
+        run: USE_SSL=1 make
+
+      - name: Run tests
+        run: $GITHUB_WORKSPACE/test.sh
+
+  centos7:
+    runs-on: ubuntu-latest
+    container: centos:7
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.GITHUB_REPOSITORY }}
+          ref: ${{ env.GITHUB_HEAD_REF }}
+
+      - name: Install redis-server
+        run: |
+          yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
+          yum -y --enablerepo=remi install redis
+          yum -y install gcc make openssl-devel
+
+      - name: Build hiredis
+        run: USE_SSL=1 make
+
+      - name: Run tests
+        run: $GITHUB_WORKSPACE/test.sh
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.GITHUB_REPOSITORY }}
+          ref: ${{ env.GITHUB_HEAD_REF }}
+
+      - name: Install dependencies
+        run: |
+          brew install openssl redis
+
+      - name: Build hiredis
+        run: USE_SSL=1 make
+
+      - name: Run tests
+        run: $GITHUB_WORKSPACE/test.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/redis/hiredis.png)](https://travis-ci.org/redis/hiredis)
+
+[![Build Status](https://github.com/redis/hiredis/actions/workflows/build.yml/badge.svg)](https://github.com/redis/hiredis/actions/workflows/build.yml)
 
 **This Readme reflects the latest changed in the master branch. See [v1.0.0](https://github.com/redis/hiredis/tree/v1.0.0) for the Readme and documentation for the latest release ([API/ABI history](https://abi-laboratory.pro/?view=timeline&l=hiredis)).**
 


### PR DESCRIPTION
Since TravisCI.org was deprecated we've been without any tests.  This
commit adds back basic tests in Ubuntu, CentOS, and macOS.

More sophisticated tests/platforms to come in the future (e.g. 32bit
tests).

Fixes #992 