### PR TITLE
Update CMakeLists.txt for more portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ ENDIF()
 
 ADD_LIBRARY(hiredis SHARED ${hiredis_sources})
 ADD_LIBRARY(hiredis_static STATIC ${hiredis_sources})
+ADD_LIBRARY(hiredis::hiredis ALIAS hiredis)
+ADD_LIBRARY(hiredis::hiredis_static ALIAS hiredis_static)
 
 SET_TARGET_PROPERTIES(hiredis
     PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE


### PR DESCRIPTION
add alias hiredis::hiredis and hiredis::hiredis_static so when this project is FetchContent-ed, it behaves the same as find_package-ed.
e.g.
```
find_package(hiredis 1.0.2 QUIET)
if (NOT hiredis_FOUND)
    FetchContent_Declare(
            hiredis
            GIT_REPOSITORY https://github.com/redis/hiredis.git
            GIT_TAG v1.0.2
    )
    FetchContent_MakeAvailable(hiredis)
endif ()
# later
target_link_libraries(target hiredis::hiredis) #can always use hiredis::hiredis to ref to this project. no matter find_package or FetchContent
```
there isnt any side effect to the installed package since ALIAS is not exported.
this is actually some sort of best practice when making a CMake lib.