### PR TITLE
Correcting the build target `coverage` for enabled SSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ USE_SSL?=0
 
 # This is required for test.c only
 ifeq ($(USE_SSL),1)
-  CFLAGS+=-DHIREDIS_TEST_SSL
+  export CFLAGS+=-DHIREDIS_TEST_SSL
 endif
 
 ifeq ($(uname_S),Linux)
@@ -299,7 +299,7 @@ gprof:
 	$(MAKE) CFLAGS="-pg" LDFLAGS="-pg"
 
 gcov:
-	$(MAKE) CFLAGS="-fprofile-arcs -ftest-coverage" LDFLAGS="-fprofile-arcs"
+	$(MAKE) CFLAGS+="-fprofile-arcs -ftest-coverage" LDFLAGS="-fprofile-arcs"
 
 coverage: gcov
 	make check

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ gcov:
 coverage: gcov
 	make check
 	mkdir -p tmp/lcov
-	lcov -d . -c -o tmp/lcov/hiredis.info
+	lcov -d . -c --exclude '/usr*' -o tmp/lcov/hiredis.info
 	genhtml --legend -o tmp/lcov/report tmp/lcov/hiredis.info
 
 noopt:


### PR DESCRIPTION
This enables test coverage measurements for SSL tests too.

`USE_SSL=1 make coverage` will now build the test binary with the forwarded define `HIREDIS_TEST_SSL`.
This avoids inconsistency between built test binary and the testrunner `test.sh`.

This PR also exclude the includes from `/usr` in the coverage reporting.