### PR TITLE
Trigger CI failure when valgrind issues are found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       #      - name: Run tests under valgrind
       #        env:
       #          SKIPS_AS_FAILS: 1
-      #          TEST_PREFIX: valgrind --track-origins=yes --leak-check=full
+      #          TEST_PREFIX: valgrind --error-exitcode=99 --track-origins=yes --leak-check=full
       #        run: $GITHUB_WORKSPACE/test.sh
 
   centos7:
@@ -75,7 +75,7 @@ jobs:
         env:
           SKIPS_AS_FAILS: 1
           TEST_SSL: 1
-          TEST_PREFIX: valgrind --track-origins=yes --leak-check=full
+          TEST_PREFIX: valgrind --error-exitcode=99 --track-origins=yes --leak-check=full
         run: $GITHUB_WORKSPACE/test.sh
 
   centos8:
@@ -115,7 +115,7 @@ jobs:
         env:
           SKIPS_AS_FAILS: 1
           TEST_SSL: 1
-          TEST_PREFIX: valgrind --track-origins=yes --leak-check=full
+          TEST_PREFIX: valgrind --error-exitcode=99 --track-origins=yes --leak-check=full
         run: $GITHUB_WORKSPACE/test.sh
 
   macos:


### PR DESCRIPTION
By default Valgrind will return the exit code from the tested process.
Since our test can return 0 (`ALL TESTS PASS`) even when a leak was found we need to tell Valgrind to return an error code instead. This will trigger a CI-job failure when issues are found.

See `--error-exitcode` in [man](https://linux.die.net/man/1/valgrind) for details.