### PR TITLE
Add asynchronous test for pubsub using RESP3

### DIFF
--- a/async.c
+++ b/async.c
@@ -496,8 +496,8 @@ static int redisIsSubscribeReply(redisReply *reply) {
     len = reply->element[0]->len - off;
 
     return !strncasecmp(str, "subscribe", len) ||
-           !strncasecmp(str, "message", len);
-
+           !strncasecmp(str, "message", len) ||
+           !strncasecmp(str, "unsubscribe", len);
 }
 
 void redisProcessCallbacks(redisAsyncContext *ac) {


### PR DESCRIPTION
This PR adds a testcase for pubsub using RESP3 and reuses the subscribe callback from the RESP2 testcase,
all to make sure we have a common behavior.
This requires a correction for `unsubscribe` responses which previously was given to the push callback.

Fixes #967