### PR TITLE
Handle array response during subscribe in RESP3

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -80,6 +80,9 @@ typedef long long ssize_t;
 /* Flag that is set when we should set SO_REUSEADDR before calling bind() */
 #define REDIS_REUSEADDR 0x80
 
+/* Flag that is set when the async connection supports push replies. */
+#define REDIS_SUPPORTS_PUSH 0x100
+
 /**
  * Flag that indicates the user does not want the context to
  * be automatically freed upon error


### PR DESCRIPTION
RESP3 allows sending commands in parallell with pubsub handling and these commands might get responded with a REDIS_REPLY_ARRAY, like `SORT`. This conflicts with the pubsub response handling for RESP2, and triggers asserts when attempting to find the subscribe callback.

This PR adds functionality to keep track of PUSH support (RESP3) on the connection to know when replies are subscribe replies.