### PR TITLE
fix the case of errno=11 and BLOCKING read mode where we should retry

### DIFF
--- a/net.c
+++ b/net.c
@@ -60,7 +60,7 @@ void redisNetClose(redisContext *c) {
 ssize_t redisNetRead(redisContext *c, char *buf, size_t bufcap) {
     ssize_t nread = recv(c->fd, buf, bufcap, 0);
     if (nread == -1) {
-        if ((errno == EWOULDBLOCK && !(c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
+        if ((errno == EWOULDBLOCK && (c->flags & REDIS_BLOCK)) || (errno == EINTR)) {
             /* Try again later */
             return 0;
         } else if(errno == ETIMEDOUT && (c->flags & REDIS_BLOCK)) {


### PR DESCRIPTION
If the client is in BLOCKING mode, then EAGAIN should be a transient problem and should not result in error. I believe there is a single character mistake in the code block where EAGAIN is checked, the ! should not have been there.