### PR TITLE
Fix integer overflow when format command larger than 4GB

### DIFF
--- a/async.c
+++ b/async.c
@@ -862,7 +862,7 @@ int redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata
 
 int redisAsyncCommandArgv(redisAsyncContext *ac, redisCallbackFn *fn, void *privdata, int argc, const char **argv, const size_t *argvlen) {
     sds cmd;
-    int len;
+    long long len;
     int status;
     len = redisFormatSdsCommandArgv(&cmd,argc,argv,argvlen);
     if (len < 0)

--- a/hiredis.c
+++ b/hiredis.c
@@ -572,13 +572,12 @@ int redisFormatCommand(char **target, const char *format, ...) {
  * lengths. If the latter is set to NULL, strlen will be used to compute the
  * argument lengths.
  */
-int redisFormatSdsCommandArgv(sds *target, int argc, const char **argv,
-                              const size_t *argvlen)
+long long redisFormatSdsCommandArgv(sds *target, int argc, const char **argv,
+                                    const size_t *argvlen)
 {
     sds cmd, aux;
-    unsigned long long totlen;
+    unsigned long long totlen, len;
     int j;
-    size_t len;
 
     /* Abort on a NULL target */
     if (target == NULL)
@@ -609,7 +608,7 @@ int redisFormatSdsCommandArgv(sds *target, int argc, const char **argv,
     cmd = sdscatfmt(cmd, "*%i\r\n", argc);
     for (j=0; j < argc; j++) {
         len = argvlen ? argvlen[j] : strlen(argv[j]);
-        cmd = sdscatfmt(cmd, "$%u\r\n", len);
+        cmd = sdscatfmt(cmd, "$%U\r\n", len);
         cmd = sdscatlen(cmd, argv[j], len);
         cmd = sdscatlen(cmd, "\r\n", sizeof("\r\n")-1);
     }
@@ -629,11 +628,11 @@ void redisFreeSdsCommand(sds cmd) {
  * lengths. If the latter is set to NULL, strlen will be used to compute the
  * argument lengths.
  */
-int redisFormatCommandArgv(char **target, int argc, const char **argv, const size_t *argvlen) {
+long long redisFormatCommandArgv(char **target, int argc, const char **argv, const size_t *argvlen) {
     char *cmd = NULL; /* final command */
-    int pos; /* position in final command */
-    size_t len;
-    int totlen, j;
+    size_t pos; /* position in final command */
+    size_t len, totlen;
+    int j;
 
     /* Abort on a NULL target */
     if (target == NULL)
@@ -1129,7 +1128,7 @@ int redisAppendCommand(redisContext *c, const char *format, ...) {
 
 int redisAppendCommandArgv(redisContext *c, int argc, const char **argv, const size_t *argvlen) {
     sds cmd;
-    int len;
+    long long len;
 
     len = redisFormatSdsCommandArgv(&cmd,argc,argv,argvlen);
     if (len == -1) {

--- a/hiredis.h
+++ b/hiredis.h
@@ -131,8 +131,8 @@ void freeReplyObject(void *reply);
 /* Functions to format a command according to the protocol. */
 int redisvFormatCommand(char **target, const char *format, va_list ap);
 int redisFormatCommand(char **target, const char *format, ...);
-int redisFormatCommandArgv(char **target, int argc, const char **argv, const size_t *argvlen);
-int redisFormatSdsCommandArgv(sds *target, int argc, const char ** argv, const size_t *argvlen);
+long long redisFormatCommandArgv(char **target, int argc, const char **argv, const size_t *argvlen);
+long long redisFormatSdsCommandArgv(sds *target, int argc, const char ** argv, const size_t *argvlen);
 void redisFreeCommand(char *cmd);
 void redisFreeSdsCommand(sds cmd);
 


### PR DESCRIPTION
See https://groups.google.com/g/redis-db/c/loPFJAqDIgI/m/GfmBKX4gDAAJ?utm_medium=email&utm_source=footer.

This PR mainly fixes two integer overflow.
1. When command arg is larger than 4GB, `hi_sdscatfmt` should use `%U`, not `%u`.
2. When the command is larger than 4GB, the return type of `redisFormatSdsCommandArgv` should be `long long`.
