### PR TITLE
Allow sending commands after sending an unsubscribe

### DIFF
--- a/async.h
+++ b/async.h
@@ -102,7 +102,6 @@ typedef struct redisAsyncContext {
 
     /* Subscription callbacks */
     struct {
-        redisCallbackList replies;
         struct dict *channels;
         struct dict *patterns;
     } sub;


### PR DESCRIPTION
Instead of handling reply callbacks in two modes or states ("normal" state and "subscribed" state)
we now use a common holder for non-subscribe callbacks.
This fixes the current issue of putting the callback in the wrong holder when going from "subscribed" state to "regular" state.

Added a test to trigger the fault.

Fixes #968 (last part)