### PR TITLE
Correction for command timeout during pubsub

### DIFF
--- a/async.c
+++ b/async.c
@@ -696,7 +696,7 @@ void redisAsyncHandleTimeout(redisAsyncContext *ac) {
     redisCallback cb;
 
     if ((c->flags & REDIS_CONNECTED)) {
-        if ( ac->replies.head == NULL) {
+        if (ac->replies.head == NULL && ac->sub.replies.head == NULL) {
             /* Nothing to do - just an idle timeout */
             return;
         }


### PR DESCRIPTION
A timeout of a non-subscribe command is ignored during pubsub,
and will be handled as an idle timeout and the response is still awaited for.

This correction triggers a disconnect instead, the same behavior as when not in the subscribed state.
