### PR TITLE
Avoid incorrect call to the previous reply's callback

### DIFF
--- a/async.c
+++ b/async.c
@@ -520,13 +520,6 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
                 __redisAsyncDisconnect(ac);
                 return;
             }
-
-            /* If monitor mode, repush callback */
-            if(c->flags & REDIS_MONITORING) {
-                redisCallback cb = {NULL, NULL, 0, NULL};
-                __redisPushCallback(&ac->replies,&cb);
-            }
-
             /* When the connection is not being disconnected, simply stop
              * trying to get replies and wait for the next loop tick. */
             break;
@@ -571,9 +564,9 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
                 __redisAsyncDisconnect(ac);
                 return;
             }
-            /* No more regular callbacks and no errors, the context *must* be subscribed or monitoring. */
-            assert((c->flags & REDIS_SUBSCRIBED || c->flags & REDIS_MONITORING));
-            if(c->flags & REDIS_SUBSCRIBED)
+            /* No more regular callbacks and no errors, the context *must* be subscribed. */
+            assert(c->flags & REDIS_SUBSCRIBED);
+            if (c->flags & REDIS_SUBSCRIBED)
                 __redisGetSubscribeCallback(ac,reply,&cb);
         }
 
@@ -594,6 +587,11 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
              * abort with an error, but simply ignore it because the client
              * doesn't know what the server will spit out over the wire. */
             c->reader->fn->freeObject(reply);
+        }
+
+        /* If in monitor mode, repush the callback */
+        if (c->flags & REDIS_MONITORING) {
+            __redisPushCallback(&ac->replies,&cb);
         }
     }
 

--- a/async.c
+++ b/async.c
@@ -508,7 +508,6 @@ static int redisIsSubscribeReply(redisReply *reply) {
 
 void redisProcessCallbacks(redisAsyncContext *ac) {
     redisContext *c = &(ac->c);
-    redisCallback cb = {NULL, NULL, 0, NULL};
     void *reply = NULL;
     int status;
 
@@ -524,6 +523,7 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
 
             /* If monitor mode, repush callback */
             if(c->flags & REDIS_MONITORING) {
+                redisCallback cb = {NULL, NULL, 0, NULL};
                 __redisPushCallback(&ac->replies,&cb);
             }
 
@@ -547,6 +547,7 @@ void redisProcessCallbacks(redisAsyncContext *ac) {
 
         /* Even if the context is subscribed, pending regular
          * callbacks will get a reply before pub/sub messages arrive. */
+        redisCallback cb = {NULL, NULL, 0, NULL};
         if (__redisShiftCallback(&ac->replies,&cb) != REDIS_OK) {
             /*
              * A spontaneous reply in a not-subscribed context can be the error


### PR DESCRIPTION
When multiple replies are parsed from a socket in one read;
a previously found callback might get reused when the current reply has no known callback.
    
This case is triggered in the added testcase `test_pubsub_multiple_channels()`,
which unsubscribes to the subscribed channels `A`, `B` and a non-subscribed channel `X`.
Without this correction a callback for wrong channel is called.
-  For the command `unsubscribe B X A`, `B`'s callback is called when handling the response for `X`.
-  Now this is not done, i.e. there is no callback called for `X`.

Monitoring was using this trait to repush its callback when all replies was parsed.
This is changed to repush for each message instead, which now also is tested with a new testcase.