### PR TITLE
CMake: remove dict.c form hiredis_sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ SET(ENABLE_EXAMPLES OFF CACHE BOOL "Enable building hiredis examples")
 SET(hiredis_sources
     alloc.c
     async.c
-    dict.c
     hiredis.c
     net.c
     read.c


### PR DESCRIPTION
Commit c6b8bd77c0fe00dbc455b39208f15761178160a3 to make all functions in dict.c static. If a CMake project set warning unused functions, and include hiredis using add_subdirectory , this cause warnings / errors.