### PR TITLE
Fix tests so they work for Redis 7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install openssl redis
+          brew install openssl redis@6.2
+          brew link redis@6.2 --force
 
       - name: Build hiredis
         run: USE_SSL=1 make

--- a/test.sh
+++ b/test.sh
@@ -5,8 +5,15 @@ REDIS_PORT=${REDIS_PORT:-56379}
 REDIS_SSL_PORT=${REDIS_SSL_PORT:-56443}
 TEST_SSL=${TEST_SSL:-0}
 SKIPS_AS_FAILS=${SKIPS_AS_FAILS-:0}
+ENABLE_DEBUG_CMD=
 SSL_TEST_ARGS=
 SKIPS_ARG=
+
+# We need to enable the DEBUG command for redis-server >= 7.0.0
+REDIS_MAJOR_VERSION="$(redis-server --version|awk -F'[^0-9]+' '{ print $2 }')"
+if [ "$REDIS_MAJOR_VERSION" -gt "6" ]; then
+    ENABLE_DEBUG_CMD="enable-debug-command local"
+fi
 
 tmpdir=$(mktemp -d)
 PID_FILE=${tmpdir}/hiredis-test-redis.pid
@@ -49,8 +56,10 @@ cleanup() {
 }
 trap cleanup INT TERM EXIT
 
+
 cat > ${tmpdir}/redis.conf <<EOF
 daemonize yes
+${ENABLE_DEBUG_CMD}
 pidfile ${PID_FILE}
 port ${REDIS_PORT}
 bind 127.0.0.1


### PR DESCRIPTION
* Redis >= 7.0.0 disables the `DEBUG` command by default, which we need
  for our unit tests.

* Downgrade to Redis 6.2.x in macOS temporarily

  There is a macOS specific TLS error on large payloads when running
  against 7.x.x so temporarily run our tests against 6.2, while we
  investigate the root cause.