### PR TITLE
Improve example for SSL initialization in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,7 @@ redisSSLContext *ssl_context;
 /* An error variable to indicate what went wrong, if the context fails to
  * initialize.
  */
-redisSSLContextError ssl_error;
+redisSSLContextError ssl_error = REDIS_SSL_CTX_NONE;
 
 /* Initialize global OpenSSL state.
  *
@@ -622,11 +622,11 @@ ssl_context = redisCreateSSLContext(
     "redis.mydomain.com",   /* Server name to request (SNI), optional */
     &ssl_error);
 
-if(ssl_context == NULL || ssl_error != 0) {
+if(ssl_context == NULL || ssl_error != REDIS_SSL_CTX_NONE) {
     /* Handle error and abort... */
     /* e.g.
     printf("SSL error: %s\n",
-        (ssl_error != 0) ?
+        (ssl_error != REDIS_SSL_CTX_NONE) ?
             redisSSLContextGetError(ssl_error) : "Unknown error");
     // Abort
     */


### PR DESCRIPTION
The previous example left `ssl_error` uninitialized. `redisCreateSSLContex` is not guaranteed to set this when no error occurs.

Use the `REDIS_SSL_CTX_NONE` constant instead of 0 to be precise.