### PR TITLE
Maintain backward compatibiliy withour onConnect callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ the disconnect callback is a good point to do so.
 Setting the connect or disconnect callbacks can only be done once per context. For subsequent calls the
 api will return `REDIS_ERR`. The function to set the callbacks have the following prototype:
 ```c
+/* Alternatively you can use redisAsyncSetConnectCallbackNC which will be passed a non-const
+   redisAsyncContext* on invocation (e.g. allowing writes to the privdata member). */
 int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn);
 int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn);
 ```

--- a/async.h
+++ b/async.h
@@ -57,7 +57,8 @@ typedef struct redisCallbackList {
 
 /* Connection callback prototypes */
 typedef void (redisDisconnectCallback)(const struct redisAsyncContext*, int status);
-typedef void (redisConnectCallback)(struct redisAsyncContext*, int status);
+typedef void (redisConnectCallback)(const struct redisAsyncContext*, int status);
+typedef void (redisConnectCallbackNC)(struct redisAsyncContext *, int status);
 typedef void(redisTimerCallback)(void *timer, void *privdata);
 
 /* Context for an async connection to Redis */
@@ -93,6 +94,7 @@ typedef struct redisAsyncContext {
 
     /* Called when the first write event was received. */
     redisConnectCallback *onConnect;
+    redisConnectCallbackNC *onConnectNC;
 
     /* Regular command callbacks */
     redisCallbackList replies;
@@ -121,6 +123,7 @@ redisAsyncContext *redisAsyncConnectBindWithReuse(const char *ip, int port,
                                                   const char *source_addr);
 redisAsyncContext *redisAsyncConnectUnix(const char *path);
 int redisAsyncSetConnectCallback(redisAsyncContext *ac, redisConnectCallback *fn);
+int redisAsyncSetConnectCallbackNC(redisAsyncContext *ac, redisConnectCallbackNC *fn);
 int redisAsyncSetDisconnectCallback(redisAsyncContext *ac, redisDisconnectCallback *fn);
 
 redisAsyncPushFn *redisAsyncSetPushCallback(redisAsyncContext *ac, redisAsyncPushFn *fn);

--- a/test.c
+++ b/test.c
@@ -2008,7 +2008,7 @@ static redisAsyncContext *do_aconnect(struct config config, astest_no testno)
 {
     redisOptions options = {0};
     memset(&astest, 0, sizeof(astest));
-    
+
     astest.testno = testno;
     astest.connect_status = astest.disconnect_status = -2;
 
@@ -2039,7 +2039,7 @@ static redisAsyncContext *do_aconnect(struct config config, astest_no testno)
     c->data = &astest;
     c->dataCleanup = asCleanup;
     redisPollAttach(c);
-    redisAsyncSetConnectCallback(c, connectCallback);
+    redisAsyncSetConnectCallbackNC(c, connectCallback);
     redisAsyncSetDisconnectCallback(c, disconnectCallback);
     return c;
 }
@@ -2058,7 +2058,7 @@ static void test_async_polling(struct config config) {
     int status;
     redisAsyncContext *c;
     struct config defaultconfig = config;
-   
+
     test("Async connect: ");
     c = do_aconnect(config, ASTEST_CONNECT);
     assert(c);
@@ -2095,7 +2095,7 @@ static void test_async_polling(struct config config) {
         test_cond(astest.connect_status == REDIS_ERR);
         config = defaultconfig;
     }
-      
+
     /* Test a ping/pong after connection */
     test("Async PING/PONG: ");
     c = do_aconnect(config, ASTEST_PINGPONG);


### PR DESCRIPTION
In f69fac7690fb22a7fc19dba61ef70e5f79ccb2e9, our async onConnect
callback was improved to take a non-const redisAsyncContext allowing it
to be reentrant.

Unfortunately, this is a breaking change we can't make until hiredis
v2.0.0.

This commit creates a separate callback member and corresponding
function that allows us to use the new functionality, while maintaining
our existing API for legacy code.

Fixes #1086