### PR TITLE
Avoid unnecessary system calls in redisAsyncCommand()

### DIFF
--- a/async.c
+++ b/async.c
@@ -950,10 +950,17 @@ static int __redisAsyncCommand(redisAsyncContext *ac, redisCallbackFn *fn, void 
         }
     }
 
+    /* We know the previous write was partial if there is data in the output
+     * buffer. So, we wait for a write event to write to the socket. Otherwise,
+     * we can directly write data to the socket. */
+    int pending_write = (sdslen(c->obuf) != 0);
+
     __redisAppendCommand(c,cmd,len);
 
-    /* Always schedule a write when the write buffer is non-empty */
-    _EL_ADD_WRITE(ac);
+    if (!pending_write)
+        redisAsyncWrite(ac);
+    else
+        _EL_ADD_WRITE(ac);
 
     return REDIS_OK;
 oom:


### PR DESCRIPTION
Currently, this is how async operations work:

1- Append new command to the output buffer.
2-  __redisAsyncCommand() registers write event unconditionally.
3-  redisAsyncWrite() will be called on the next iteration of the event loop.
4- Write event will be cleared.

Steps 2 and 4 are system calls. They introduce unnecessary overhead.

For better performance, we can directly write to the socket(step-3)
without registering a write event. Still, it is better to detect if the write
event is already registered. In this case, we won't try to write to the socket 
as it will probably fail (because the socket buffer is full).  
