### PR TITLE
Fix some undefined behavior

### DIFF
--- a/examples/example-libevent-ssl.c
+++ b/examples/example-libevent-ssl.c
@@ -56,7 +56,7 @@ int main (int argc, char **argv) {
     const char *caCert = argc > 5 ? argv[6] : NULL;
 
     redisSSLContext *ssl;
-    redisSSLContextError ssl_error;
+    redisSSLContextError ssl_error = REDIS_SSL_CTX_NONE;
 
     redisInitOpenSSL();
 

--- a/examples/example-ssl.c
+++ b/examples/example-ssl.c
@@ -12,7 +12,7 @@
 int main(int argc, char **argv) {
     unsigned int j;
     redisSSLContext *ssl;
-    redisSSLContextError ssl_error;
+    redisSSLContextError ssl_error = REDIS_SSL_CTX_NONE;
     redisContext *c;
     redisReply *reply;
     if (argc < 4) {
@@ -27,9 +27,8 @@ int main(int argc, char **argv) {
 
     redisInitOpenSSL();
     ssl = redisCreateSSLContext(ca, NULL, cert, key, NULL, &ssl_error);
-    if (!ssl) {
-        printf("SSL Context error: %s\n",
-                redisSSLContextGetError(ssl_error));
+    if (!ssl || ssl_error != REDIS_SSL_CTX_NONE) {
+        printf("SSL Context error: %s\n", redisSSLContextGetError(ssl_error));
         exit(1);
     }
 


### PR DESCRIPTION
- redisSSLContextError must always be initialized at defintion,
  otherwise when SSL connect succeeds it may not be assigned to a valid error.
  Thus the memory trash remains in the variable, which may sign a misleading error.