### PR TITLE
Introduce .close method for redisContextFuncs

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -48,6 +48,7 @@ extern int redisContextUpdateConnectTimeout(redisContext *c, const struct timeva
 extern int redisContextUpdateCommandTimeout(redisContext *c, const struct timeval *timeout);
 
 static redisContextFuncs redisContextDefaultFuncs = {
+    .close = redisNetClose,
     .free_privctx = NULL,
     .async_read = redisAsyncRead,
     .async_write = redisAsyncWrite,
@@ -722,7 +723,10 @@ static redisContext *redisContextInit(void) {
 void redisFree(redisContext *c) {
     if (c == NULL)
         return;
-    redisNetClose(c);
+
+    if (c->funcs && c->funcs->close) {
+        c->funcs->close(c);
+    }
 
     sdsfree(c->obuf);
     redisReaderFree(c->reader);
@@ -759,7 +763,9 @@ int redisReconnect(redisContext *c) {
         c->privctx = NULL;
     }
 
-    redisNetClose(c);
+    if (c->funcs && c->funcs->close) {
+        c->funcs->close(c);
+    }
 
     sdsfree(c->obuf);
     redisReaderFree(c->reader);

--- a/hiredis.h
+++ b/hiredis.h
@@ -234,6 +234,7 @@ typedef struct {
     (opts)->free_privdata = dtor;                    \
 
 typedef struct redisContextFuncs {
+    void (*close)(struct redisContext *);
     void (*free_privctx)(void *);
     void (*async_read)(struct redisAsyncContext *);
     void (*async_write)(struct redisAsyncContext *);

--- a/ssl.c
+++ b/ssl.c
@@ -32,6 +32,7 @@
 
 #include "hiredis.h"
 #include "async.h"
+#include "net.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -579,6 +580,7 @@ static void redisSSLAsyncWrite(redisAsyncContext *ac) {
 }
 
 redisContextFuncs redisContextSSLFuncs = {
+    .close = redisNetClose,
     .free_privctx = redisSSLFree,
     .async_read = redisSSLAsyncRead,
     .async_write = redisSSLAsyncWrite,


### PR DESCRIPTION
Currently, hiredis supports TCP/SSL/Unix, all of the connection types
use a single FD(int), close() is enough to close a connection. For the
further step, introduce .close method for redisContextFuncs, this
allows to close a complex connection context, for example RDMA.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>