### PR TITLE
Add possibility to prefer IPv6, IPv4 or unspecified

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -809,6 +809,12 @@ redisContext *redisConnectWithOptions(const redisOptions *options) {
     if (options->options & REDIS_OPT_NOAUTOFREEREPLIES) {
         c->flags |= REDIS_NO_AUTO_FREE_REPLIES;
     }
+    if (options->options & REDIS_OPT_PREFER_IPV4) {
+        c->flags |= REDIS_PREFER_IPV4;
+    }
+    if (options->options & REDIS_OPT_PREFER_IPV6) {
+        c->flags |= REDIS_PREFER_IPV6;
+    }
 
     /* Set any user supplied RESP3 PUSH handler or use freeReplyObject
      * as a default unless specifically flagged that we don't want one. */

--- a/hiredis.h
+++ b/hiredis.h
@@ -92,6 +92,11 @@ typedef long long ssize_t;
 /* Flag that indicates the user does not want replies to be automatically freed */
 #define REDIS_NO_AUTO_FREE_REPLIES 0x400
 
+/* Flags to prefer IPv6 or IPv4 when doing DNS lookup. (If both are set,
+ * AF_UNSPEC is used.) */
+#define REDIS_PREFER_IPV4 0x800
+#define REDIS_PREFER_IPV6 0x1000
+
 #define REDIS_KEEPALIVE_INTERVAL 15 /* seconds */
 
 /* number of times we retry to connect in the case of EADDRNOTAVAIL and
@@ -149,6 +154,8 @@ struct redisSsl;
 
 #define REDIS_OPT_NONBLOCK 0x01
 #define REDIS_OPT_REUSEADDR 0x02
+#define REDIS_OPT_PREFER_IPV4 0x04
+#define REDIS_OPT_PREFER_IPV6 0x08
 
 /**
  * Don't automatically free the async object on a connection failure,


### PR DESCRIPTION
Adds options to select preferred IP stack.

* REDIS_OPT_PREFER_IPV4 = Try IPv4 first, then IPv6 if no IPv4 was found
* REDIS_OPT_PREFER_IPV6 = Try IPv6 first, then IPv4 if no IPv4 was found
* Both flags set = Use getaddrinfo() with AF_UNSPEC. This allows the user or sysadmin to configure preferred IP stacks in /etc/gai.conf.

* None of these flags set = Try IPv4 first, for historical reasons.

Fixes #696.