### PR TITLE
Fix heap-buffer-overflow issue in redisvFormatCommad

### DIFF
--- a/fuzzing/format_command_fuzzer.c
+++ b/fuzzing/format_command_fuzzer.c
@@ -48,10 +48,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     memcpy(new_str, data, size);
     new_str[size] = '\0';
 
-    redisFormatCommand(&cmd, new_str);
-
-    if (cmd != NULL)
+    if (redisFormatCommand(&cmd, new_str) != -1)
         hi_free(cmd);
+
     free(new_str);
     return 0;
 }

--- a/hiredis.c
+++ b/hiredis.c
@@ -399,6 +399,11 @@ int redisvFormatCommand(char **target, const char *format, va_list ap) {
                     /* Copy va_list before consuming with va_arg */
                     va_copy(_cpy,ap);
 
+                    /* Make sure we have more characters otherwise strchr() accepts
+                     * '\0' as an integer specifier. This is checked after above
+                     * va_copy() to avoid UB in fmt_invalid's call to va_end(). */
+                    if (*_p == '\0') goto fmt_invalid;
+
                     /* Integer conversion (without modifiers) */
                     if (strchr(intfmts,*_p) != NULL) {
                         va_arg(ap,int);

--- a/test.c
+++ b/test.c
@@ -330,8 +330,12 @@ static void test_format_commands(void) {
     FLOAT_WIDTH_TEST(float);
     FLOAT_WIDTH_TEST(double);
 
-    test("Format command with invalid printf format: ");
+    test("Format command with unhandled printf format (specifier 'p' not supported): ");
     len = redisFormatCommand(&cmd,"key:%08p %b",(void*)1234,"foo",(size_t)3);
+    test_cond(len == -1);
+
+    test("Format command with invalid printf format (specifier missing): ");
+    len = redisFormatCommand(&cmd,"%-");
     test_cond(len == -1);
 
     const char *argv[3];


### PR DESCRIPTION
A command with a faulty formatting string that lacks the conversion specifier (the type) results in a ASAN heap-buffer-overflow.
This was due to that strchr() matches on null-termination, which triggers a continuation of the string parsing.

Fixes #956 which uses formatting string `# % ` (0x23,0x20,0x25,0x20) where the flag `space` comes after `%`,
i.e also a missing type specifier.

The alternative fix in #957 would make the added testcase return a command string (`*1\r\n$0\r\n\r\n`, len=10),
but since the same formatting string used in `printf` will also fail I think this is better.