### PR TITLE
uvadapter: reduce number of uv_poll_start calls

### DIFF
--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -30,6 +30,10 @@ static void redisLibuvPoll(uv_poll_t* handle, int status, int events) {
 static void redisLibuvAddRead(void *privdata) {
     redisLibuvEvents* p = (redisLibuvEvents*)privdata;
 
+    if (p->events & UV_READABLE) {
+        return;
+    }
+
     p->events |= UV_READABLE;
 
     uv_poll_start(&p->handle, p->events, redisLibuvPoll);
@@ -51,6 +55,10 @@ static void redisLibuvDelRead(void *privdata) {
 
 static void redisLibuvAddWrite(void *privdata) {
     redisLibuvEvents* p = (redisLibuvEvents*)privdata;
+
+    if (p->events & UV_WRITABLE) {
+        return;
+    }
 
     p->events |= UV_WRITABLE;
 


### PR DESCRIPTION
Internally uv_poll_start iterates over all
attached event handlers to update event mask. It's
quite expensive operation if there many event handlers attached
to a loop.
As redisLibuvEvents.events is a copy of what libuv should see,
we can rely on it to avoid event mask updates.

Signed-off-by: Anton Tiurin <noxiouz@yandex.ru>