### PR TITLE
Fix an ASAN issue in redisvFormatCommand()

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -364,6 +364,7 @@ int redisvFormatCommand(char **target, const char *format, va_list ap) {
             switch(c[1]) {
             case 's':
                 arg = va_arg(ap,char*);
+                if (arg == NULL) break; /* argument missing */
                 size = strlen(arg);
                 if (size > 0)
                     newarg = sdscatlen(curarg,arg,size);

--- a/test.c
+++ b/test.c
@@ -353,18 +353,6 @@ static void test_format_commands(void) {
         len == 4+4+2);
     hi_free(cmd);
 
-    test("Format command with missing integer argument for %%d: ");
-    len = redisFormatCommand(&cmd,"%d");
-    test_cond(strncmp(cmd,"*1\r\n$1\r\n0\r\n",len) == 0 &&
-        len == 4+4+3);
-    hi_free(cmd);
-
-    test("Format command with missing argument for %%b: ");
-    len = redisFormatCommand(&cmd,"%b", "");
-    test_cond(strncmp(cmd,"*1\r\n$0\r\n\r\n",len) == 0 &&
-        len == 4+4+2);
-    hi_free(cmd);
-
     const char *argv[3];
     argv[0] = "SET";
     argv[1] = "foo\0xxx";

--- a/test.c
+++ b/test.c
@@ -347,6 +347,24 @@ static void test_format_commands(void) {
     len = redisFormatCommand(&cmd,"%-");
     test_cond(len == -1);
 
+    test("Format command with missing string argument for %%s: ");
+    len = redisFormatCommand(&cmd,"%s");
+    test_cond(strncmp(cmd,"*1\r\n$0\r\n\r\n",len) == 0 &&
+        len == 4+4+2);
+    hi_free(cmd);
+
+    test("Format command with missing integer argument for %%d: ");
+    len = redisFormatCommand(&cmd,"%d");
+    test_cond(strncmp(cmd,"*1\r\n$1\r\n0\r\n",len) == 0 &&
+        len == 4+4+3);
+    hi_free(cmd);
+
+    test("Format command with missing argument for %%b: ");
+    len = redisFormatCommand(&cmd,"%b", "");
+    test_cond(strncmp(cmd,"*1\r\n$0\r\n\r\n",len) == 0 &&
+        len == 4+4+2);
+    hi_free(cmd);
+
     const char *argv[3];
     argv[0] = "SET";
     argv[1] = "foo\0xxx";


### PR DESCRIPTION
Calling the standard function `strlen()` with `null` causes undefined behavior.
This is triggered when the string argument is missing for a `%s` command format.

Note:
- The formatted output command the added tests are not changed due to the correction.
- One could argue the importance of this fix.