### PR TITLE
Fix pkgconfig result for hiredis_ssl

### DIFF
--- a/hiredis_ssl.pc.in
+++ b/hiredis_ssl.pc.in
@@ -1,6 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
+install_libdir=@CMAKE_INSTALL_LIBDIR@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/${install_libdir}
 includedir=${prefix}/include
 pkgincludedir=${includedir}/hiredis
 


### PR DESCRIPTION
Respect an overridden libdir when installing using CMake.
CMake now generates the `hiredis_ssl.pc` file with the correct result in `libdir` and `Libs`.

See #767 for same fix in `hiredis.pc`