### PR TITLE
Use __attribute__ when building with Clang on Windows

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -35,9 +35,11 @@
 
 #define SDS_MAX_PREALLOC (1024*1024)
 #ifdef _MSC_VER
-#define __attribute__(x)
 typedef long long ssize_t;
 #define SSIZE_MAX (LLONG_MAX >> 1)
+#ifndef __clang__
+#define __attribute__(x)
+#endif
 #endif
 
 #include <sys/types.h>


### PR DESCRIPTION
Since Clang supports `__attribute__` we can avoid disabling it and use packed `sdshdrX` structs when building with Clang on Windows. This also make sure we don't affect subsequent header files that require `__attribute__`.

Note:
Clang attempts to be a drop-in replacement for MSVC and therefor defines `_MSC_VER` to be able to use existing libraries/headers.

Fixes #1042