### PR TITLE
Additional include directory given by pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,20 +275,22 @@ $(PKGCONFNAME): hiredis.h
 	@echo prefix=$(PREFIX) > $@
 	@echo exec_prefix=\$${prefix} >> $@
 	@echo libdir=$(PREFIX)/$(LIBRARY_PATH) >> $@
-	@echo includedir=$(PREFIX)/$(INCLUDE_PATH) >> $@
+	@echo includedir=$(PREFIX)/include >> $@
+	@echo pkgincludedir=$(PREFIX)/$(INCLUDE_PATH) >> $@
 	@echo >> $@
 	@echo Name: hiredis >> $@
 	@echo Description: Minimalistic C client library for Redis. >> $@
 	@echo Version: $(HIREDIS_MAJOR).$(HIREDIS_MINOR).$(HIREDIS_PATCH) >> $@
 	@echo Libs: -L\$${libdir} -lhiredis >> $@
-	@echo Cflags: -I\$${includedir} -D_FILE_OFFSET_BITS=64 >> $@
+	@echo Cflags: -I\$${pkgincludedir} -I\$${includedir} -D_FILE_OFFSET_BITS=64 >> $@
 
 $(SSL_PKGCONFNAME): hiredis_ssl.h
 	@echo "Generating $@ for pkgconfig..."
 	@echo prefix=$(PREFIX) > $@
 	@echo exec_prefix=\$${prefix} >> $@
 	@echo libdir=$(PREFIX)/$(LIBRARY_PATH) >> $@
-	@echo includedir=$(PREFIX)/$(INCLUDE_PATH) >> $@
+	@echo includedir=$(PREFIX)/include >> $@
+	@echo pkgincludedir=$(PREFIX)/$(INCLUDE_PATH) >> $@
 	@echo >> $@
 	@echo Name: hiredis_ssl >> $@
 	@echo Description: SSL Support for hiredis. >> $@

--- a/README.md
+++ b/README.md
@@ -609,8 +609,8 @@ unaffected so no additional dependencies are introduced.
 First, you'll need to make sure you include the SSL header file:
 
 ```c
-#include "hiredis.h"
-#include "hiredis_ssl.h"
+#include <hiredis/hiredis.h>
+#include <hiredis/hiredis_ssl.h>
 ```
 
 You will also need to link against `libhiredis_ssl`, **in addition** to

--- a/hiredis.pc.in
+++ b/hiredis.pc.in
@@ -9,4 +9,4 @@ Name: hiredis
 Description: Minimalistic C client library for Redis.
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lhiredis
-Cflags: -I${pkgincludedir} -D_FILE_OFFSET_BITS=64
+Cflags: -I${pkgincludedir} -I${includedir} -D_FILE_OFFSET_BITS=64


### PR DESCRIPTION
The pkg-config installed by either Make or CMake now gives an additional include directory which
enables users to include hiredis headers with:
`#include <hiredis/hiredis.h>`.
The legacy path is kept for backwards compatibility.

Example before:

    # pkg-config hiredis --cflags
    -D_FILE_OFFSET_BITS=64 -I/usr/local/include/hiredis

Example output with PR:

    # pkg-config hiredis --cflags
    -D_FILE_OFFSET_BITS=64 -I/usr/local/include/hiredis -I/usr/local/include

    # gcc examples/example.c $(pkg-config --cflags --libs hiredis)  # Still finds <hiredis.h>
                                                                    # but also  <hiredis/hiredis.h> if example is updated.

Fixes #1044 and #627 

Reference:
See commonly used spec of variable [pkgincludedir](https://www.sourceware.org/autobook/autobook/autobook_76.html).
