### PR TITLE
Update for mingw cross compile

### DIFF
--- a/sockcompat.h
+++ b/sockcompat.h
@@ -50,7 +50,7 @@
 #include <ws2tcpip.h>
 #include <stddef.h>
 #include <errno.h>
-#include <Mstcpip.h>
+#include <mstcpip.h>
 
 #ifdef _MSC_VER
 typedef long long ssize_t;


### PR DESCRIPTION
	- Used lowercase for Mstcpip.h as mingw will not find the file otherwise
	- Smallest PR ever, with only a single character change