### PR TITLE
Add support for nan in RESP3 double

### DIFF
--- a/read.c
+++ b/read.c
@@ -303,11 +303,13 @@ static int processLineItem(redisReader *r) {
                 d = INFINITY; /* Positive infinite. */
             } else if (len == 4 && strcasecmp(buf,"-inf") == 0) {
                 d = -INFINITY; /* Negative infinite. */
+            } else if (len == 3 && strcasecmp(buf,"nan") == 0) {
+                d = NAN; /* nan. */
             } else {
                 d = strtod((char*)buf,&eptr);
                 /* RESP3 only allows "inf", "-inf", and finite values, while
-                 * strtod() allows other variations on infinity, NaN,
-                 * etc. We explicity handle our two allowed infinite cases
+                 * strtod() allows other variations on infinity,
+                 * etc. We explicity handle our two allowed infinite cases and NaN
                  * above, so strtod() should only result in finite values. */
                 if (buf[0] == '\0' || eptr != &buf[len] || !isfinite(d)) {
                     __redisReaderSetError(r,REDIS_ERR_PROTOCOL,

--- a/test.c
+++ b/test.c
@@ -674,12 +674,13 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
-    test("Set error when RESP3 double is NaN: ");
+    test("Correctly parses RESP3 double NaN: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, ",nan\r\n",6);
     ret = redisReaderGetReply(reader,&reply);
-    test_cond(ret == REDIS_ERR &&
-              strcasecmp(reader->errstr,"Bad double value") == 0);
+    test_cond(ret == REDIS_OK &&
+              ((redisReply*)reply)->type == REDIS_REPLY_DOUBLE &&
+              isnan(((redisReply*)reply)->dval));
     freeReplyObject(reply);
     redisReaderFree(reader);
 


### PR DESCRIPTION
Given https://github.com/redis/redis-specifications/pull/10, addresses https://github.com/redis/redis-specifications/issues/9 in hiredis. 