### PR TITLE
Make freeing a NULL redisAsyncContext a no op.

### DIFF
--- a/async.c
+++ b/async.c
@@ -413,7 +413,11 @@ static void __redisAsyncFree(redisAsyncContext *ac) {
  * free'ing. To do so, a flag is set on the context which is picked up by
  * redisProcessCallbacks(). Otherwise, the context is immediately free'd. */
 void redisAsyncFree(redisAsyncContext *ac) {
+    if (ac == NULL)
+        return;
+
     redisContext *c = &(ac->c);
+
     c->flags |= REDIS_FREEING;
     if (!(c->flags & REDIS_IN_CALLBACK))
         __redisAsyncFree(ac);


### PR DESCRIPTION
This makes our behavior consistent with redisFree and freeReplyObject.