### PR TITLE
Fix wincrypt symbols conflict

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -40,6 +40,14 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <wincrypt.h>
+#ifdef OPENSSL_IS_BORINGSSL
+#undef X509_NAME
+#undef X509_EXTENSIONS
+#undef PKCS7_ISSUER_AND_SERIAL
+#undef PKCS7_SIGNER_INFO
+#undef OCSP_REQUEST
+#undef OCSP_RESPONSE
+#endif
 #else
 #include <pthread.h>
 #endif


### PR DESCRIPTION
With openssl variants such as boring ssl, the conflict symbols are not undefined such as openssl.
Explicit undefine those so it works for both normal openssl and  boring ssl