### PR TITLE
Write a version file for the CMake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,6 @@ endif()
 SET(INCLUDE_INSTALL_DIR include)
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/hiredis-config-version.cmake"
-                                 VERSION ${VERSION}
                                  COMPATIBILITY SameMajorVersion)
 configure_package_config_file(hiredis-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/hiredis-config.cmake
                               INSTALL_DESTINATION ${CMAKE_CONF_INSTALL_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,9 @@ else()
 endif()
 SET(INCLUDE_INSTALL_DIR include)
 include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/hiredis-config-version.cmake"
+                                 VERSION ${VERSION}
+                                 COMPATIBILITY SameMajorVersion)
 configure_package_config_file(hiredis-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/hiredis-config.cmake
                               INSTALL_DESTINATION ${CMAKE_CONF_INSTALL_DIR}
                               PATH_VARS INCLUDE_INSTALL_DIR)
@@ -164,6 +167,7 @@ INSTALL(EXPORT hiredis-targets
         DESTINATION ${CMAKE_CONF_INSTALL_DIR})
 
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/hiredis-config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/hiredis-config-version.cmake
         DESTINATION ${CMAKE_CONF_INSTALL_DIR})
 
 


### PR DESCRIPTION
This enables users to ask for a specific version of hiredis via `find_package`.

Setting `COMPATIBILITY SameMajorVersion` means that CMake considers newer versions as compatible as long as the major version matches, e.g., asking for `1.1` will succeed when finding `1.2` but not when finding `2.0`. I hope this is the desired behavior. :)

CMake docs: https://cmake.org/cmake/help/v3.0/module/CMakePackageConfigHelpers.html#module:CMakePackageConfigHelpers.