### PR TITLE
Add RedisModule adapter

### DIFF
--- a/adapters/redismoduleapi.h
+++ b/adapters/redismoduleapi.h
@@ -1,0 +1,100 @@
+#ifndef __HIREDIS_REDISMODULEAPI_H__
+#define __HIREDIS_REDISMODULEAPI_H__
+
+#include "redismodule.h"
+
+#include "../async.h"
+#include "../hiredis.h"
+
+#include <sys/types.h>
+
+typedef struct redisModuleEvents {
+    redisAsyncContext *context;
+    int fd;
+    int reading, writing;
+} redisModuleEvents;
+
+static void redisModuleReadEvent(int fd, void *privdata, int mask) {
+    (void) fd;
+    (void) mask;
+
+    redisModuleEvents *e = (redisModuleEvents*)privdata;
+    redisAsyncHandleRead(e->context);
+}
+
+static void redisModuleWriteEvent(int fd, void *privdata, int mask) {
+    (void) fd;
+    (void) mask;
+
+    redisModuleEvents *e = (redisModuleEvents*)privdata;
+    redisAsyncHandleWrite(e->context);
+}
+
+static void redisModuleAddRead(void *privdata) {
+    redisModuleEvents *e = (redisModuleEvents*)privdata;
+    if (!e->reading) {
+        e->reading = 1;
+        RedisModule_EventLoopAdd(e->fd, REDISMODULE_EVENTLOOP_READABLE, redisModuleReadEvent, e);
+    }
+}
+
+static void redisModuleDelRead(void *privdata) {
+    redisModuleEvents *e = (redisModuleEvents*)privdata;
+    if (e->reading) {
+        e->reading = 0;
+        RedisModule_EventLoopDel(e->fd, REDISMODULE_EVENTLOOP_READABLE);
+    }
+}
+
+static void redisModuleAddWrite(void *privdata) {
+    redisModuleEvents *e = (redisModuleEvents*)privdata;
+    if (!e->writing) {
+        e->writing = 1;
+        RedisModule_EventLoopAdd(e->fd, REDISMODULE_EVENTLOOP_WRITABLE, redisModuleWriteEvent, e);
+    }
+}
+
+static void redisModuleDelWrite(void *privdata) {
+    redisModuleEvents *e = (redisModuleEvents*)privdata;
+    if (e->writing) {
+        e->writing = 0;
+        RedisModule_EventLoopDel(e->fd, REDISMODULE_EVENTLOOP_WRITABLE);
+    }
+}
+
+static void redisModuleCleanup(void *privdata) {
+    redisModuleEvents *e = (redisModuleEvents*)privdata;
+    redisModuleDelRead(privdata);
+    redisModuleDelWrite(privdata);
+    hi_free(e);
+}
+
+static int redisModuleAttach(redisAsyncContext *ac) {
+    redisContext *c = &(ac->c);
+    redisModuleEvents *e;
+
+    /* Nothing should be attached when something is already attached */
+    if (ac->ev.data != NULL)
+        return REDIS_ERR;
+
+    /* Create container for context and r/w events */
+    e = (redisModuleEvents*)hi_malloc(sizeof(*e));
+    if (e == NULL)
+        return REDIS_ERR;
+
+    e->context = ac;
+    e->fd = c->fd;
+    e->reading = e->writing = 0;
+
+    /* Register functions to start/stop listening for events */
+    ac->ev.addRead = redisModuleAddRead;
+    ac->ev.delRead = redisModuleDelRead;
+    ac->ev.addWrite = redisModuleAddWrite;
+    ac->ev.delWrite = redisModuleDelWrite;
+    ac->ev.cleanup = redisModuleCleanup;
+    ac->ev.data = e;
+
+    return REDIS_OK;
+}
+
+#endif

--- a/examples/example-redismoduleapi.c
+++ b/examples/example-redismoduleapi.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+
+#include <hiredis.h>
+#include <async.h>
+#include <adapters/redismoduleapi.h>
+
+void getCallback(redisAsyncContext *c, void *r, void *privdata) {
+    redisReply *reply = r;
+    if (reply == NULL) {
+        if (c->errstr) {
+            printf("errstr: %s\n", c->errstr);
+        }
+        return;
+    }
+    printf("argv[%s]: %s\n", (char*)privdata, reply->str);
+
+    /* Disconnect after receiving the reply to GET */
+    redisAsyncDisconnect(c);
+}
+
+void connectCallback(const redisAsyncContext *c, int status) {
+    if (status != REDIS_OK) {
+        printf("Error: %s\n", c->errstr);
+        return;
+    }
+    printf("Connected...\n");
+}
+
+void disconnectCallback(const redisAsyncContext *c, int status) {
+    if (status != REDIS_OK) {
+        printf("Error: %s\n", c->errstr);
+        return;
+    }
+    printf("Disconnected...\n");
+}
+
+/*
+ * This example requires Redis 7.0 or above.
+ *
+ * 1- Compile this file as a shared library. Directory of "redismodule.h" must
+ *    be in the include path.
+ *       gcc -fPIC -shared -I../../redis/src/ -I.. example-redismoduleapi.c -o example-redismoduleapi.so
+ *
+ * 2- Load module:
+ *       redis-server --loadmodule ./example-redismoduleapi.so value
+ */
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+
+    int ret = RedisModule_Init(ctx, "example-redismoduleapi", 1, REDISMODULE_APIVER_1);
+    if (ret != REDISMODULE_OK) {
+        printf("error module init \n");
+        return REDISMODULE_ERR;
+    }
+
+    if (!RedisModule_GetServerVersion ||
+        RedisModule_GetServerVersion() < 0x00070000) {
+        printf("Redis 7.0 or above is required! \n");
+        return REDISMODULE_ERR;
+    }
+
+    redisAsyncContext *c = redisAsyncConnect("127.0.0.1", 6379);
+    if (c->err) {
+        /* Let *c leak for now... */
+        printf("Error: %s\n", c->errstr);
+        return 1;
+    }
+
+    size_t len;
+    const char *val = RedisModule_StringPtrLen(argv[argc-1], &len);
+
+    redisModuleAttach(c);
+    redisAsyncSetConnectCallback(c,connectCallback);
+    redisAsyncSetDisconnectCallback(c,disconnectCallback);
+    redisAsyncCommand(c, NULL, NULL, "SET key %b", val, len);
+    redisAsyncCommand(c, getCallback, (char*)"end-1", "GET key");
+    return 0;
+}


### PR DESCRIPTION
Starting from this commit: https://github.com/redis/redis/pull/10001, redis (v7.0+) exposes its event loop from the module API. 
This PR adds an adapter to attach hiredis to redis' event loop. By doing that, a redis module can send commands to other redis instances via async hiredis. 


