### PR TITLE
Helper for setting TCP_USER_TIMEOUT socket option

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -953,6 +953,11 @@ int redisEnableKeepAlive(redisContext *c) {
     return redisKeepAlive(c, REDIS_KEEPALIVE_INTERVAL);
 }
 
+/* Set the socket option TCP_USER_TIMEOUT. */
+int redisSetTcpUserTimeout(redisContext *c, unsigned int timeout) {
+    return redisContextSetTcpUserTimeout(c, timeout);
+}
+
 /* Set a user provided RESP3 PUSH handler and return any old one set. */
 redisPushFn *redisSetPushCallback(redisContext *c, redisPushFn *fn) {
     redisPushFn *old = c->push_cb;

--- a/hiredis.h
+++ b/hiredis.h
@@ -323,6 +323,7 @@ redisPushFn *redisSetPushCallback(redisContext *c, redisPushFn *fn);
 int redisSetTimeout(redisContext *c, const struct timeval tv);
 int redisEnableKeepAlive(redisContext *c);
 int redisEnableKeepAliveWithInterval(redisContext *c, int interval);
+int redisSetTcpUserTimeout(redisContext *c, unsigned int timeout);
 void redisFree(redisContext *c);
 redisFD redisFreeKeepFd(redisContext *c);
 int redisBufferRead(redisContext *c);

--- a/net.c
+++ b/net.c
@@ -228,6 +228,22 @@ int redisSetTcpNoDelay(redisContext *c) {
     return REDIS_OK;
 }
 
+int redisContextSetTcpUserTimeout(redisContext *c, unsigned int timeout) {
+    int res;
+#ifdef TCP_USER_TIMEOUT
+    res = setsockopt(c->fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout, sizeof(timeout));
+#else
+    res = -1;
+    (void)timeout;
+#endif
+    if (res == -1); {
+        __redisSetErrorFromErrno(c,REDIS_ERR_IO,"setsockopt(TCP_USER_TIMEOUT)");
+        redisNetClose(c);
+        return REDIS_ERR;
+    }
+    return REDIS_OK;
+}
+
 #define __MAX_MSEC (((LONG_MAX) - 999) / 1000)
 
 static int redisContextTimeoutMsec(redisContext *c, long *result)

--- a/net.h
+++ b/net.h
@@ -52,5 +52,6 @@ int redisKeepAlive(redisContext *c, int interval);
 int redisCheckConnectDone(redisContext *c, int *completed);
 
 int redisSetTcpNoDelay(redisContext *c);
+int redisContextSetTcpUserTimeout(redisContext *c, unsigned int timeout);
 
 #endif


### PR DESCRIPTION
This adds another option in the same style as the TCP KeepAlive feature, i.e. passing the option directly to setsockopt() without storing it in the context, meaning it does not happen automatically after redisReconnect().

It is already possible to achieve this by taking the fd out of the redisContext as `c->fd`, so it is not strictly necessary to add this.

Documentation is added in README also for the keepalive feature.