### PR TITLE
Ensure functionality without `_MSC_VER` definition

### DIFF
--- a/test.c
+++ b/test.c
@@ -78,7 +78,7 @@ static int tests = 0, fails = 0, skips = 0;
 
 static void millisleep(int ms)
 {
-#if _MSC_VER
+#ifdef _MSC_VER
     Sleep(ms);
 #else
     usleep(ms*1000);


### PR DESCRIPTION
When building with a compiler that is not the Microsoft C/C++ compiler (MSVC), I get the error `error: "_MSC_VER" is not defined`.

I checked the code and it looks like you just want to make sure _MSV_VER is defined, so I changed it from `#if` to `#ifdef`.