### PR TITLE
fixed `ISO C90 forbids mixed declarations and code`

### DIFF
--- a/net.c
+++ b/net.c
@@ -306,11 +306,11 @@ static int redisContextWaitReady(redisContext *c, long msec) {
 
 int redisCheckConnectDone(redisContext *c, int *completed) {
     int rc = connect(c->fd, (const struct sockaddr *)c->saddr, c->addrlen);
+    int error = errno;
     if (rc == 0) {
         *completed = 1;
         return REDIS_OK;
     }
-    int error = errno;
     if (error == EINPROGRESS) {
         /* must check error to see if connect failed.  Get the socket error */
         int fail, so_error;


### PR DESCRIPTION
I got an error `error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]`, so I fixed the ISO C90 violation in net.c.

Specifically, we are attempting to resolve this by moving the definition of `error` to the beginning of the file.