### PR TITLE
Fix a false positive warning of gcc 12+ -Werror=maybe-uninitialized

### DIFF
--- a/test.c
+++ b/test.c
@@ -1340,7 +1340,7 @@ static void test_blocking_io_errors(struct config config) {
 }
 
 static void test_invalid_timeout_errors(struct config config) {
-    redisContext *c;
+    redisContext *c = NULL;
 
     test("Set error when an invalid timeout usec value is used during connect: ");
 
@@ -1355,7 +1355,7 @@ static void test_invalid_timeout_errors(struct config config) {
         assert(NULL);
     }
 
-    test_cond(c->err == REDIS_ERR_IO && strcmp(c->errstr, "Invalid timeout specified") == 0);
+    test_cond(c != NULL && c->err == REDIS_ERR_IO && strcmp(c->errstr, "Invalid timeout specified") == 0);
     redisFree(c);
 
     test("Set error when an invalid timeout sec value is used during connect: ");
@@ -1371,7 +1371,7 @@ static void test_invalid_timeout_errors(struct config config) {
         assert(NULL);
     }
 
-    test_cond(c->err == REDIS_ERR_IO && strcmp(c->errstr, "Invalid timeout specified") == 0);
+    test_cond(c != NULL && c->err == REDIS_ERR_IO && strcmp(c->errstr, "Invalid timeout specified") == 0);
     redisFree(c);
 }
 


### PR DESCRIPTION
Hello, 
The warning I have (which is treated as error) looks like this: 

```
gcc-ar rcs libhiredis_ssl.a ssl.o
gcc -std=c99 -c -O3 -fPIC  -I/vg/hiredis/DEPS/root/include -DNDEBUG -O3 -fno-lto -ffat-lto-objects -fuse-linker-plugin -std=gnu17 -fno-working-directory -ggdb3 -I/vg/hiredis/DEPS/root/include -Wall -Wextra -Werror -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers -g -ggdb  -pedantic test.c
test.c: In function 'test_invalid_timeout_errors':
test.c:1358:16: error: 'c' may be used uninitialized [-Werror=maybe-uninitialized]
 1358 |     test_cond(c->err == REDIS_ERR_IO && strcmp(c->errstr, "Invalid timeout specified") == 0);
      |               ~^~~~~
test.c:76:26: note: in definition of macro 'test_cond'
   76 | #define test_cond(_c) if(_c) printf("\033[0;32mPASSED\033[0;0m\n"); else {printf("\033[0;31mFAILED\033[0;0m\n"); fails++;}
      |                          ^~
test.c:1343:19: note: 'c' was declared here
 1343 |     redisContext *c;
      |                   ^
cc1: all warnings being treated as errors
make: *** [Makefile:270: test.o] Error 1
```

I reproduced it with gcc 12 and 13 (I didn't try on any previous versions)

Thanks,
V

