### PR TITLE
Allow disabling the -Werror flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,11 @@ export REDIS_TEST_CONFIG
 CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || echo g++')
 OPTIMIZATION?=-O3
-WARNINGS=-Wall -Wextra -Werror -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers
+WARNINGS=-Wall -Wextra -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers
+USE_WERROR?=1
+ifeq ($(USE_WERROR),1)
+  WARNINGS+=-Werror
+endif
 DEBUG_FLAGS?= -g -ggdb
 REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(PLATFORM_FLAGS)
 REAL_LDFLAGS=$(LDFLAGS)


### PR DESCRIPTION
This follows my message in #1193, packagers usually don't want to enable `-Werror`, this is only for developers working on Redis itself.

Typically right now we tried to upgrade to hiredis 1.2.0, we force using LTO in our builds, and we also build tests (to at least run the test and make sure our toolchain doesn't seem to buggy). With gcc 11, we get lots of false positive warnings in sds.c (wrong stringop-overflow warnings, warning which is known to create quite some problems here and there since it was introduced), which don't come out with gcc 13. Given how old is gcc 11 now and given that it doesn't happen with gcc 13, I doubt that reporting this bugs to the gcc project will help.

So is such an opt-out flag ok or not ? I copied what was done for `USE_SSL`.