### PR TITLE
Stop hardcoding -std=c99 explicitly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ check: hiredis-test
 	TEST_SSL=$(USE_SSL) ./test.sh
 
 .c.o:
-	$(CC) -std=c99 -c $(REAL_CFLAGS) $<
+	$(CC) -c $(REAL_CFLAGS) $<
 
 clean:
 	rm -rf $(DYLIBNAME) $(STLIBNAME) $(SSL_DYLIBNAME) $(SSL_STLIBNAME) $(TESTS) $(PKGCONFNAME) examples/hiredis-example* *.o *.gcda *.gcno *.gcov


### PR DESCRIPTION
Gcc since gcc >= 5 uses C11 (which superseeds C99). Clang uses C11 (or C17) since at least Clang >= 3.3 Gcc 5 was released in april 2015.

The reasoning here is that distros (packagers) already force some default dialect. It's not super important in C, but in C++ it matters more to have all the libraries ideally built with the very same dialect. Now compilers have adopted the idea that when a standard is "well implemented" and was "battle-tested" a bit, it shall be defined as the default dialect (typically couple of years after it was initially introduced). Usually libraries vendor are advised to check that the default feature (here C99) are used by default, instead of forcing them. 

Also if really we wanted to enforce this C99 flag, it should have been done in the global flag variable rather than here in the middle of the makefile.

In our case, our build system ensures C17 for now (by defininng it in the environment $CFLAGS)