### PR TITLE
Make redisEnableKeepAlive a no-op on AF_UNIX connections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /*.pc
 *.dSYM
 tags
+compile_commands.json

--- a/net.c
+++ b/net.c
@@ -173,6 +173,10 @@ int redisKeepAlive(redisContext *c, int interval) {
     int val = 1;
     redisFD fd = c->fd;
 
+    /* TCP_KEEPALIVE makes no sense with AF_UNIX connections */
+    if (c->connection_type == REDIS_CONN_UNIX)
+        return REDIS_ERR;
+
 #ifndef _WIN32
     if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) == -1){
         __redisSetError(c,REDIS_ERR_OTHER,strerror(errno));


### PR DESCRIPTION
This commit turns `redisEnableKeepAlive` into a no-op for `REDIS_CONN_UNIX` connections.

I'm not sure there's much benefit by actually breaking the connection (e.g. setting `c-.err` and `c->errstr`) for the operation, so instead we just return `REDIS_ERR` from `redisEnableKeepAlive` but leave the connection in a good state.

Fixes #1185