### PR TITLE
CI: Update Homebrew Redis version and the freebsd-vm action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install openssl redis@7.0
-          brew link redis@7.0 --force
+          brew install openssl redis@7.2
+          brew link redis@7.2 --force
 
       - name: Build hiredis
         run: USE_SSL=1 make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,13 +112,13 @@ jobs:
         run: $GITHUB_WORKSPACE/test.sh
 
   freebsd:
-    runs-on: macos-12
+    runs-on: ubuntu-22.04
     name:  FreeBSD
     steps:
       - uses: actions/checkout@v3
 
       - name: Build in FreeBSD
-        uses: vmactions/freebsd-vm@v0
+        uses: vmactions/freebsd-vm@v1
         with:
           prepare: pkg install -y gmake cmake
           run: |


### PR DESCRIPTION
- Update Homebrew Redis version 
    Use latest 7.2 since 7.0 was removed from [Other version](https://formulae.brew.sh/formula/redis).

- Update `vmactions/freebsd-vm`   
    Use latest version since the previous version now do cyclic reboots..
    Now runs on Ubuntu as [required](https://github.com/vmactions/freebsd-vm).