### PR TITLE
Fix memory leak.

### DIFF
--- a/adapters/libuv.h
+++ b/adapters/libuv.h
@@ -159,6 +159,7 @@ static int redisLibuvAttach(redisAsyncContext* ac, uv_loop_t* loop) {
     memset(p, 0, sizeof(*p));
 
     if (uv_poll_init_socket(loop, &p->handle, c->fd) != 0) {
+        hi_free(p);
         return REDIS_ERR;
     }
 


### PR DESCRIPTION
When redisLibuvAttach receives error from call to
uv_poll_init_socket there is a memory leaked ptr
of type redisLibuvEvents.