### PR TITLE
[cmake] Fix cmake options position to support cmake toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
 
-OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)
-OPTION(ENABLE_SSL "Build hiredis_ssl for SSL support" OFF)
-OPTION(DISABLE_TESTS "If tests should be compiled or not" OFF)
-OPTION(ENABLE_SSL_TESTS "Should we test SSL connections" OFF)
-OPTION(ENABLE_EXAMPLES "Enable building hiredis examples" OFF)
-OPTION(ENABLE_ASYNC_TESTS "Should we run all asynchronous API tests" OFF)
-# Historically, the NuGet file was always install; default
-# to ON for those who rely on that historical behaviour.
-OPTION(ENABLE_NUGET "Install NuGET packaging details" ON)
-
 MACRO(getVersionBit name)
   SET(VERSION_REGEX "^#define ${name} (.+)$")
   FILE(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/hiredis.h"
@@ -26,6 +16,16 @@ MESSAGE("Detected version: ${VERSION}")
 
 PROJECT(hiredis LANGUAGES "C" VERSION "${VERSION}")
 INCLUDE(GNUInstallDirs)
+
+OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)
+OPTION(ENABLE_SSL "Build hiredis_ssl for SSL support" OFF)
+OPTION(DISABLE_TESTS "If tests should be compiled or not" OFF)
+OPTION(ENABLE_SSL_TESTS "Should we test SSL connections" OFF)
+OPTION(ENABLE_EXAMPLES "Enable building hiredis examples" OFF)
+OPTION(ENABLE_ASYNC_TESTS "Should we run all asynchronous API tests" OFF)
+# Historically, the NuGet file was always install; default
+# to ON for those who rely on that historical behaviour.
+OPTION(ENABLE_NUGET "Install NuGET packaging details" ON)
 
 # Hiredis requires C99
 SET(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
Greetings!

By declaring options in the [CMake toolchain](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html) after the project() command in the CMakeLists.txt, you ensure that they are applied within the context of the project's environment, making them more coherent and ensuring that they override any default settings appropriately. 

However, the current CMakeLists.txt declares `options()` first, before `project()`, which means, the context is not initialized and the options values from toolchain is ignored.

The current scenario WITHOUT this PR:

```cmake
# hiredis_toolchain.cmake
set(BUILD_SHARED_LIBS OFF)
set(ENABLE_SSL ON)
set(DISABLE_TESTS ON)
set(ENABLE_SSL_TESTS OFF)
set(ENABLE_EXAMPLES OFF)
set(ENABLE_ASYNC_TESTS OFF)
```

`cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=hiredis_toolchain.cmake`

```
% cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=hiredis_toolchain.cmake -LAH
Detected version: 1.2.0
-- The C compiler identification is AppleClang 15.0.0.15000100
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found OpenSSL: /opt/homebrew/Cellar/openssl@3/3.2.0_1/lib/libcrypto.dylib (found version "3.2.0")  
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/uilian/Development/hiredis/build
-- Cache values
// Build shared libraries
BUILD_SHARED_LIBS:BOOL=ON

// The CMake toolchain file
CMAKE_TOOLCHAIN_FILE:FILEPATH=/Users/uilian/Development/hiredis/hiredis_toolchain.cmake

// Enable building hiredis examples
ENABLE_EXAMPLES:BOOL=OFF

// Install NuGET packaging details
ENABLE_NUGET:BOOL=ON

// Build hiredis_ssl for SSL support
ENABLE_SSL:BOOL=OFF

// Should we test SSL connections
ENABLE_SSL_TESTS:BOOL=OFF

```

As you can see, the toolchain file is consumed, but CMake ignores its values. 

In order to fix the current situation, `options()` should be moved after `project()`.