### PR TITLE
Remove dead assignment in sdstrim.

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -692,10 +692,10 @@ fmt_error:
  * Output will be just "Hello World".
  */
 sds sdstrim(sds s, const char *cset) {
-    char *start, *end, *sp, *ep;
+    char *end, *sp, *ep;
     size_t len;
 
-    sp = start = s;
+    sp = s;
     ep = end = s+sdslen(s)-1;
     while(sp <= end && strchr(cset, *sp)) sp++;
     while(ep > sp && strchr(cset, *ep)) ep--;


### PR DESCRIPTION
The assignment is harmless but causes noise in static analysers