### PR TITLE
Test for both EAGAIN and EINPROGRESS for AF_UNIX sockets.

### DIFF
--- a/net.c
+++ b/net.c
@@ -668,7 +668,7 @@ int redisContextConnectUnix(redisContext *c, const char *path, const struct time
     sa->sun_family = AF_UNIX;
     strncpy(sa->sun_path, path, sizeof(sa->sun_path) - 1);
     if (connect(c->fd, (struct sockaddr*)sa, sizeof(*sa)) == -1) {
-        if (errno == EINPROGRESS && !blocking) {
+        if ((errno == EAGAIN || errno == EINPROGRESS) && !blocking) {
             /* This is ok. */
         } else {
             if (redisContextWaitReady(c,timeout_msec) != REDIS_OK)


### PR DESCRIPTION
Reading the manpage it seems like we only need to test for `EAGAIN` but testing for both seems more prudent since this may be subtly different on more esoteric kernels (SunOS, AIX, BSD, etc).

Also explicitly install openSSL3 on macOS.

Fixes #1260