### PR TITLE
Make test.sh use REDIS_SERVER everywhere

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ SKIPS_ARG=${SKIPS_ARG:-}
 REDIS_DOCKER=${REDIS_DOCKER:-}
 
 # We need to enable the DEBUG command for redis-server >= 7.0.0
-REDIS_MAJOR_VERSION="$(redis-server --version|awk -F'[^0-9]+' '{ print $2 }')"
+REDIS_MAJOR_VERSION="$(${REDIS_SERVER} --version|awk -F'[^0-9]+' '{ print $2 }')"
 if [ "$REDIS_MAJOR_VERSION" -gt "6" ]; then
     ENABLE_DEBUG_CMD="enable-debug-command local"
 fi
@@ -98,7 +98,7 @@ if [ -n "${REDIS_DOCKER}" ] ; then
         -p ${REDIS_SSL_PORT}:${REDIS_SSL_PORT} \
         -v ${tmpdir}:${tmpdir} \
         ${REDIS_DOCKER} \
-        redis-server ${tmpdir}/redis.conf
+        ${REDIS_SERVER} ${tmpdir}/redis.conf
 else
     ${REDIS_SERVER} ${tmpdir}/redis.conf
 fi


### PR DESCRIPTION
Fedora is moving to valkey (see https://fedoraproject.org/wiki/Changes/Replace_Redis_With_Valkey).  This allows use to use valkey-server for the tests.