### PR TITLE
Update old link for modules-api-ref.md

### DIFF
--- a/async.c
+++ b/async.c
@@ -478,7 +478,7 @@ static int __redisGetSubscribeCallback(redisAsyncContext *ac, redisReply *reply,
 
     /* Match reply with the expected format of a pushed message.
      * The type and number of elements (3 to 4) are specified at:
-     * https://redis.io/topics/pubsub#format-of-pushed-messages */
+     * https://redis.io/docs/latest/develop/interact/pubsub/#format-of-pushed-messages */
     if ((reply->type == REDIS_REPLY_ARRAY && !(c->flags & REDIS_SUPPORTS_PUSH) && reply->elements >= 3) ||
         reply->type == REDIS_REPLY_PUSH) {
         assert(reply->element[0]->type == REDIS_REPLY_STRING);


### PR DESCRIPTION
 This PR contains a change to a link that appears in the modules API docs when the redis/redis/utils/generate-module-api-doc.rb script is run. This is needed by the automation @paoloredis put in place to automatically update redis/redis/commands.json content when a new GA release is tagged.

@oranagra suggested I make the change here as well.