### PR TITLE
(Docs)fix wrong commands of enabling SSL/TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,13 @@ When enabled, SSL/TLS support is built into extra `libhiredis_ssl.a` and
 `libhiredis_ssl.so` static/dynamic libraries. This leaves the original libraries
 unaffected so no additional dependencies are introduced.
 
+Run the following commands to build and install hiredis_ssl: 
+```
+$ cmake . -DENABLE_SSL=ON
+$ make USE_SSL=1
+$ sudo make install
+```
+
 ### Using it
 
 First, you'll need to make sure you include the SSL header file:


### PR DESCRIPTION
In the SSL/TLS support part, the current readme says to run `make USE_SSL=1` to build and install files related to hiredis_ssl. However, after running it, the system does not install the `libhiredis_ssl` correctly.

This is due to the option here in `CMakeLists.txt` is set to OFF as default but `make USE_SSL=1` does not enable it.
```
OPTION(ENABLE_SSL "Build hiredis_ssl for SSL support" OFF)
```

This is the result of just running `make USE_SSL=1` and `sudo make install`
```
mkdir -p /usr/local/include/hiredis /usr/local/include/hiredis/adapters /usr/local/lib
cp -pPR hiredis.h async.h read.h sds.h alloc.h sockcompat.h /usr/local/include/hiredis
cp -pPR adapters/*.h /usr/local/include/hiredis/adapters
cp -pPR libhiredis.so /usr/local/lib/libhiredis.so.1.2.1-dev
cd /usr/local/lib && ln -sf libhiredis.so.1.2.1-dev libhiredis.so && ln -sf libhiredis.so.1.2.1-dev libhiredis.so.1
cp -pPR libhiredis.a /usr/local/lib
mkdir -p /usr/local/lib/pkgconfig
cp -pPR hiredis.pc /usr/local/lib/pkgconfig
```

This is the result of running `cmake . -DENABLE_SSL=ON` before the commands above.
```
[ 66%] Built target hiredis
[ 83%] Built target hiredis_ssl
[100%] Built target hiredis-test
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/lib64/libhiredis.so.1.2.1-dev
-- Installing: /usr/local/lib64/libhiredis.so
-- Installing: /usr/local/build/native/hiredis.targets
-- Up-to-date: /usr/local/include/hiredis/hiredis.h
-- Up-to-date: /usr/local/include/hiredis/read.h
-- Up-to-date: /usr/local/include/hiredis/sds.h
-- Up-to-date: /usr/local/include/hiredis/async.h
-- Up-to-date: /usr/local/include/hiredis/alloc.h
-- Up-to-date: /usr/local/include/hiredis/sockcompat.h
-- Up-to-date: /usr/local/include/hiredis/adapters
-- Up-to-date: /usr/local/include/hiredis/adapters/macosx.h
-- Up-to-date: /usr/local/include/hiredis/adapters/ae.h
-- Up-to-date: /usr/local/include/hiredis/adapters/libev.h
-- Up-to-date: /usr/local/include/hiredis/adapters/libevent.h
-- Up-to-date: /usr/local/include/hiredis/adapters/poll.h
-- Up-to-date: /usr/local/include/hiredis/adapters/redismoduleapi.h
-- Up-to-date: /usr/local/include/hiredis/adapters/qt.h
-- Up-to-date: /usr/local/include/hiredis/adapters/libsdevent.h
-- Up-to-date: /usr/local/include/hiredis/adapters/glib.h
-- Up-to-date: /usr/local/include/hiredis/adapters/libhv.h
-- Up-to-date: /usr/local/include/hiredis/adapters/ivykis.h
-- Up-to-date: /usr/local/include/hiredis/adapters/libuv.h
-- Installing: /usr/local/lib64/pkgconfig/hiredis.pc
-- Installing: /usr/local/lib64/cmake/hiredis/hiredis-targets.cmake
-- Installing: /usr/local/lib64/cmake/hiredis/hiredis-targets-noconfig.cmake
-- Installing: /usr/local/lib64/cmake/hiredis/hiredis-config.cmake
-- Installing: /usr/local/lib64/cmake/hiredis/hiredis-config-version.cmake
-- Installing: /usr/local/lib64/libhiredis_ssl.so.1.2.1-dev
-- Installing: /usr/local/lib64/libhiredis_ssl.so
-- Installing: /usr/local/include/hiredis/hiredis_ssl.h
-- Installing: /usr/local/lib64/pkgconfig/hiredis_ssl.pc
-- Installing: /usr/local/lib64/cmake/hiredis_ssl/hiredis_ssl-targets.cmake
-- Installing: /usr/local/lib64/cmake/hiredis_ssl/hiredis_ssl-targets-noconfig.cmake
-- Installing: /usr/local/lib64/cmake/hiredis_ssl/hiredis_ssl-config.cmake
```

So it's obvious to see that files of `libhiredis_ssl.so`, `hiredis_ssl.h` and so on are left out and not installed correctly as expected. Thus I add the commands in the `README.md` to fix the problem since it's really hard to detect.
