### PR TITLE
Do not explicitly initialize openSSL in newer versions

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -167,8 +167,8 @@ static int initOpensslLocks(void) {
 
 int redisInitOpenSSL(void)
 {
-    SSL_library_init();
 #ifdef HIREDIS_USE_CRYPTO_LOCKS
+    SSL_library_init();
     initOpensslLocks();
 #endif
 


### PR DESCRIPTION
Recentish openSSL versions have implicit initialization and is better to let it be, unless you have something special to do.