### PR TITLE
Define ssize_t as intptr_t in Windows

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -39,7 +39,7 @@
 #include <sys/time.h> /* for struct timeval */
 #else
 struct timeval; /* forward declaration */
-typedef long long ssize_t;
+typedef intptr_t ssize_t;
 #endif
 #include <stdint.h> /* uintXX_t, etc */
 #include "sds.h" /* for sds */

--- a/sds.h
+++ b/sds.h
@@ -35,8 +35,8 @@
 
 #define SDS_MAX_PREALLOC (1024*1024)
 #ifdef _MSC_VER
-typedef long long ssize_t;
-#define SSIZE_MAX (LLONG_MAX >> 1)
+typedef intptr_t ssize_t;
+#define SSIZE_MAX INTPTR_MAX
 #ifndef __clang__
 #define __attribute__(x)
 #endif

--- a/sockcompat.h
+++ b/sockcompat.h
@@ -53,7 +53,7 @@
 #include <mstcpip.h>
 
 #ifdef _MSC_VER
-typedef long long ssize_t;
+typedef intptr_t ssize_t;
 #endif
 
 /* Emulate the parts of the BSD socket API that we need (override the winsock signatures). */


### PR DESCRIPTION
After checking, the modification typedef intptr_t ssize_t; is more suitable as it self-adapts to the platform and won't cause conflicts when combined with asynchronous libuv under Win32.