### PR TITLE
Fix buffer overflow in tests.

### DIFF
--- a/test.c
+++ b/test.c
@@ -850,7 +850,7 @@ static void test_reply_reader(void) {
 
     test("Can parse RESP3 doubles in an array: ");
     reader = redisReaderCreate();
-    redisReaderFeed(reader, "*1\r\n,3.14159265358979323846\r\n",31);
+    redisReaderFeed(reader, "*1\r\n,3.14159265358979323846\r\n",29);
     ret = redisReaderGetReply(reader,&reply);
     test_cond(ret == REDIS_OK &&
         ((redisReply*)reply)->type == REDIS_REPLY_ARRAY &&


### PR DESCRIPTION
The length of this string is 30 not 31. This patch fixes a buffer overflow found by address sanitizer:

```
=================================================================
==564795==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00000046531e at pc 0x7efedd8e4ad7 bp 0x7ffd5854d330 sp 0x7ffd5854caf0
READ of size 31 at 0x00000046531e thread T0
    #0 0x7efedd8e4ad6 in memcpy (/lib64/libasan.so.8+0xe4ad6) (BuildId: 6a82bb83b1f19d3f3a2118085acf79daa3b52371)
    #1 0x00000042c7fa in sdscatlen /home/collin/.local/src/hiredis/sds.c:386
    #2 0x000000450f1d in redisReaderFeed /home/collin/.local/src/hiredis/read.c:729
    #3 0x0000004057be in test_reply_reader /home/collin/.local/src/hiredis/test.c:853
    #4 0x0000004057be in main /home/collin/.local/src/hiredis/test.c:2378
    #5 0x7efedce115f4 in __libc_start_call_main (/lib64/libc.so.6+0x35f4) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #6 0x7efedce116a7 in __libc_start_main@@GLIBC_2.34 (/lib64/libc.so.6+0x36a7) (BuildId: 2b3c02fe7e4d3811767175b6f323692a10a4e116)
    #7 0x00000040bb54 in _start (/home/collin/.local/src/hiredis/hiredis-test+0x40bb54) (BuildId: eeb44cadf688f5f645493587f947a64fd150c28f)

0x00000046531e is located 34 bytes before global variable '*.LC334' defined in 'test.c' (0x000000465340) of size 5
  '*.LC334' is ascii string '6379'
0x00000046531e is located 0 bytes after global variable '*.LC333' defined in 'test.c' (0x000000465300) of size 30
  '*.LC333' is ascii string '*1
,3.14159265358979323846
'
SUMMARY: AddressSanitizer: global-buffer-overflow /home/collin/.local/src/hiredis/sds.c:386 in sdscatlen
```