### PR TITLE
Fix CI on MacOS runners.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install openssl redis@7.2
-          brew link redis@7.2 --force
+          brew install openssl redis@8.0
+          brew link redis@8.0 --force
 
       - name: Build hiredis
         run: USE_SSL=1 make


### PR DESCRIPTION
Install redis@8.0 from Homebrew since redis@7.2 was removed.