### PR TITLE
Fix CI for macOS and docker based runs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install openssl redis@8.0
-          brew link redis@8.0 --force
+          brew install openssl redis
+          brew link redis --force
 
       - name: Build hiredis
         run: USE_SSL=1 make
@@ -158,7 +158,7 @@ jobs:
         with:
           cmake-version: ${{ matrix.cmake-version }}
       - name: Install hiredis dependencies
-        run: |          
+        run: |
           sudo apt-get install -y libssl-dev libevent-dev
       - name: Build
         run: |


### PR DESCRIPTION
It used to be neccessary to specify `redis@8.2` to get the latest version but this is now the default.

The only named version is the legacy `redis@6.2`.