### PR TITLE
Add C++ compatibility to sds.h

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -46,6 +46,10 @@ typedef intptr_t ssize_t;
 #include <stdarg.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef char *sds;
 
 /* Note: sdshdr5 is never used, we just access the flags byte directly.
@@ -277,4 +281,7 @@ void sds_free(void *ptr);
 int sdsTest(int argc, char *argv[]);
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
https://github.com/RediSearch/RediSearch recently started requiring `sds` access for tests. Since the repo uses C++ for tests, this requires C++ compatibility in from hiredis for linking to work.