### PR TITLE
Support overriding CMAKE_DEBUG_POSTFIX in CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ OPTION(ENABLE_NUGET "Install NuGET packaging details" ON)
 
 # Hiredis requires C99
 SET(CMAKE_C_STANDARD 99)
-SET(CMAKE_DEBUG_POSTFIX d)
+IF(NOT DEFINED CMAKE_DEBUG_POSTFIX)
+    SET(CMAKE_DEBUG_POSTFIX d)
+ENDIF()
 
 SET(hiredis_sources
     alloc.c


### PR DESCRIPTION
In some environments it is not desirable to postfix the name of the debug build artifact with 'd'. Add support for overriding this behavior.