### PR TITLE
Protect against overflow of map elements

### DIFF
--- a/read.c
+++ b/read.c
@@ -535,7 +535,21 @@ static int processAggregateItem(redisReader *r) {
 
             moveToNextTask(r);
         } else {
-            if (cur->type == REDIS_REPLY_MAP || cur->type == REDIS_REPLY_ATTR) elements *= 2;
+            if (cur->type == REDIS_REPLY_MAP || cur->type == REDIS_REPLY_ATTR) {
+                long long maxelements = LLONG_MAX / 2;
+                if (LLONG_MAX > SIZE_MAX &&
+                    maxelements > (long long)(SIZE_MAX / 2)) {
+                    maxelements = (long long)(SIZE_MAX / 2);
+                }
+
+                if (elements > maxelements) {
+                    __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                            "Multi-bulk length out of range");
+                    return REDIS_ERR;
+                }
+
+                elements *= 2;
+            }
 
             if (r->fn && r->fn->createArray)
                 obj = r->fn->createArray(cur,elements);

--- a/test.c
+++ b/test.c
@@ -795,6 +795,15 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
+    test("A RESP3 MAP/ATTR can't overflow: ");
+    reader = redisReaderCreate();
+    reader->maxelements = 0; /* Don't rely on default limit */
+    redisReaderFeed(reader, "%4611686018427387904\r\n", 22);
+    ret = redisReaderGetReply(reader, &reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
+    redisReaderFree(reader);
+
     test("Can parse RESP3 attribute: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, "|2\r\n+foo\r\n:123\r\n+bar\r\n#t\r\n",26);


### PR DESCRIPTION
For `RESP3` map containers we double the number of elements sent via the protocol since each element is a key-value pair.

Before the change this could overflow if a user explicitly disabled the default `reader->maxelements` setting and then tried to parse a map or attribute reply with > `LLONG_MAX / 2` elements.

Fixes #1322

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core reply parsing for RESP3 MAP/ATTR containers; incorrect bounds logic could reject valid replies or miss edge-case overflows, but the change is small and covered by a regression test.
> 
> **Overview**
> Prevents integer overflow when parsing RESP3 `MAP`/`ATTR` aggregates by bounding the element count *before* doubling it for key/value pairs, and returning a protocol error (`Multi-bulk length out of range`) when the length is unrepresentable.
> 
> Adds a regression test that disables `maxelements` and verifies oversized MAP/ATTR lengths fail with the expected error instead of overflowing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af083b42bbfc7b72bd0292bb4ce6dacdc7125acb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->