### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -46,9 +46,9 @@ typedef intptr_t ssize_t;
 #include "alloc.h" /* for allocation wrappers */
 
 #define HIREDIS_MAJOR 1
-#define HIREDIS_MINOR 3
+#define HIREDIS_MINOR 4
 #define HIREDIS_PATCH 0
-#define HIREDIS_SONAME 1.3.0
+#define HIREDIS_SONAME 1.4.0
 
 /* Connection type can be blocking or non-blocking and is set in the
  * least significant bit of the flags field in redisContext. */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version define changes with no runtime or API logic modified in this diff.
> 
> **Overview**
> Bumps the public **hiredis** release identifiers in `hiredis.h` from **1.3.0** to **1.4.0**: `HIREDIS_MINOR` (3 → 4) and `HIREDIS_SONAME` (1.3.0 → 1.4.0). `HIREDIS_MAJOR` and `HIREDIS_PATCH` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecc0013292ad8575b8ea1da2236f0a99c30fff45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->