### PR TITLE
Bump version to 1.5.0-dev

### DIFF
--- a/hiredis.h
+++ b/hiredis.h
@@ -46,9 +46,9 @@ typedef intptr_t ssize_t;
 #include "alloc.h" /* for allocation wrappers */
 
 #define HIREDIS_MAJOR 1
-#define HIREDIS_MINOR 4
+#define HIREDIS_MINOR 5
 #define HIREDIS_PATCH 0
-#define HIREDIS_SONAME 1.4.0
+#define HIREDIS_SONAME 1.5.0-dev
 
 /* Connection type can be blocking or non-blocking and is set in the
  * least significant bit of the flags field in redisContext. */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version macro-only change with no runtime or API logic modified.
> 
> **Overview**
> Bumps the public **hiredis** version identifiers in `hiredis.h` from **1.4.0** to **1.5.0-dev**: `HIREDIS_MINOR` **4 → 5** and `HIREDIS_SONAME` **`1.4.0` → `1.5.0-dev`**. `HIREDIS_MAJOR` and `HIREDIS_PATCH` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1b64cfd98b345b5147189fb271ec61cbd7990e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->