### PR TITLE
Upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     name: Ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     container: rockylinux:8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -79,10 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     name:  FreeBSD
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Build in FreeBSD
-        uses: vmactions/freebsd-vm@v1.0.5
+        uses: vmactions/freebsd-vm@v1
         with:
           prepare: pkg install -y gmake cmake
           run: |
@@ -93,7 +93,7 @@ jobs:
     name: macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -112,7 +112,7 @@ jobs:
     name: Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -152,7 +152,7 @@ jobs:
           '4.0.0' # Latest version
         ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@v2
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         with:
           # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
            config-name: release-drafter-config.yml

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check Spelling
         uses: rojopolis/spellcheck-github-actions@0.33.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - name: Install prerequisites
       run: sudo apt-get update && sudo apt-get install -y libev-dev libevent-dev libglib2.0-dev libssl-dev valgrind
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Run make
       run: make all examples
     - name: Run unittests
@@ -34,7 +34,7 @@ jobs:
     steps:
     - name: Install prerequisites
       run: sudo apt-get update && sudo apt-get install gcc-multilib
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Run make
       run: make all
       env:
@@ -64,7 +64,7 @@ jobs:
     - name: Install platform toolset
       if: matrix.toolset
       run: sudo apt-get install -y gcc-${{matrix.toolset}}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Run make
       run: make all
       env:
@@ -81,7 +81,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: microsoft/setup-msbuild@v1.0.2
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Run CMake (shared lib)
         run: cmake -Wno-dev CMakeLists.txt
       - name: Build hiredis (shared lib)


### PR DESCRIPTION
Preparation for Node.js v20 deprecation on GitHub Actions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only workflow action version pins change; no application or library code is modified.
> 
> **Overview**
> Bumps CI workflow dependencies so pipelines stay compatible ahead of GitHub’s Node.js 20 runtime deprecation.
> 
> Across **build**, **test**, and **spellcheck** workflows, every `actions/checkout` step moves from **v3/v4** to **v6**. **release-drafter** goes from **v5** to **v7** in `release-drafter.yml`. The FreeBSD job in `build.yml` also pins **vmactions/freebsd-vm** from **v1.0.5** to the **v1** major tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d54c4e7e2e5ddb2f0082482fe2e2e3226b4a123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->