### PR TITLE
Add a `maxdepth` `redisReader` configuration member.

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,16 @@ unlimited with:
 context->reader->maxelements = 0;
 ```
 
+### Reader max nesting depth
+
+By default the hiredis reply parser limits nested aggregate replies to a depth
+of `REDIS_READER_MAX_REPLY_DEPTH` (currently 1024). If you need to process
+replies nested more deeply, you can increase the value or set it to zero,
+meaning unlimited with:
+```c
+context->reader->maxdepth = 0;
+```
+
 ## SSL/TLS Support
 
 ### Building

--- a/read.c
+++ b/read.c
@@ -557,6 +557,12 @@ static int processAggregateItem(redisReader *r) {
     long long elements;
     int root = 0, len;
 
+    if (r->maxdepth > 0 && r->ridx >= r->maxdepth) {
+        __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                "Max nesting depth exceeded");
+        return REDIS_ERR;
+    }
+
     if (r->ridx == r->tasks - 1) {
         if (redisReaderGrow(r) == REDIS_ERR)
             return REDIS_ERR;
@@ -751,6 +757,7 @@ redisReader *redisReaderCreateWithFunctions(redisReplyObjectFunctions *fn) {
     r->fn = fn;
     r->maxbuf = REDIS_READER_MAX_BUF;
     r->maxelements = REDIS_READER_MAX_ARRAY_ELEMENTS;
+    r->maxdepth = REDIS_READER_MAX_REPLY_DEPTH;
     r->ridx = -1;
 
     return r;

--- a/read.h
+++ b/read.h
@@ -104,7 +104,6 @@ typedef struct redisReader {
     size_t len; /* Buffer length */
     size_t maxbuf; /* Max length of unused buffer */
     long long maxelements; /* Max multi-bulk elements */
-    int maxdepth; /* Max nested aggregate reply depth */
 
     redisReadTask **task;
     int tasks;
@@ -114,6 +113,8 @@ typedef struct redisReader {
 
     redisReplyObjectFunctions *fn;
     void *privdata;
+
+    int maxdepth; /* Max nested aggregate reply depth */
 } redisReader;
 
 /* Public API for the protocol parser. */

--- a/read.h
+++ b/read.h
@@ -69,6 +69,9 @@
 /* Default multi-bulk element limit */
 #define REDIS_READER_MAX_ARRAY_ELEMENTS ((1LL<<32) - 1)
 
+/* Default maximum depth of nested aggregate replies. */
+#define REDIS_READER_MAX_REPLY_DEPTH 1024
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -101,6 +104,7 @@ typedef struct redisReader {
     size_t len; /* Buffer length */
     size_t maxbuf; /* Max length of unused buffer */
     long long maxelements; /* Max multi-bulk elements */
+    int maxdepth; /* Max nested aggregate reply depth */
 
     redisReadTask **task;
     int tasks;

--- a/test.c
+++ b/test.c
@@ -497,6 +497,46 @@ static void test_reply_reader(void) {
     freeReplyObject(root);
     redisReaderFree(reader);
 
+    test("Reader sets a default maximum nesting depth: ");
+    reader = redisReaderCreate();
+    test_cond(reader->maxdepth == REDIS_READER_MAX_REPLY_DEPTH);
+    redisReaderFree(reader);
+
+    test("Can parse a reply at the maximum nesting depth: ");
+    reader = redisReaderCreate();
+    reader->fn = NULL;
+    for (i = 0; i < REDIS_READER_MAX_REPLY_DEPTH; i++) {
+        redisReaderFeed(reader,(char*)"*1\r\n",4);
+    }
+    redisReaderFeed(reader,(char*)"+OK\r\n",5);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK && reply == (void*)REDIS_REPLY_ARRAY);
+    redisReaderFree(reader);
+
+    test("Set error when nesting depth exceeds the configured maximum: ");
+    reader = redisReaderCreate();
+    for (i = 0; i <= REDIS_READER_MAX_REPLY_DEPTH; i++) {
+        redisReaderFeed(reader,(char*)"*1\r\n",4);
+    }
+    redisReaderFeed(reader,(char*)"+OK\r\n",5);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr,"Max nesting depth exceeded") == 0);
+    freeReplyObject(reply);
+    redisReaderFree(reader);
+
+    test("Can disable the maximum nesting depth: ");
+    reader = redisReaderCreate();
+    reader->maxdepth = 0;
+    reader->fn = NULL;
+    for (i = 0; i <= REDIS_READER_MAX_REPLY_DEPTH; i++) {
+        redisReaderFeed(reader,(char*)"*1\r\n",4);
+    }
+    redisReaderFeed(reader,(char*)"+OK\r\n",5);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK && reply == (void*)REDIS_REPLY_ARRAY);
+    redisReaderFree(reader);
+
     test("Correctly parses LLONG_MAX: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, ":9223372036854775807\r\n",22);


### PR DESCRIPTION
Currently hiredis will attempt to parse arbitrarily nested `RESP` replies. During normal operation this is not a problem but a corrupted or maliciously crafted payload could cause a stack overflow.

This commit just adds `redisReader->maxdepth` which has the same semantics as our existing `redisReader->maxelements` so by default hiredis clients will error out if the depth reaches 1024.

This should be far higher than real-world workloads are likely to hit while being much lower than a depth that could overflow the stack.

Vulnurability discovered by:
He Huang, hehuang@swin.edu.au, Swinburne University of Technology, Melbourne, Australia; discovery using NexusSan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protocol parsing on untrusted input (security-relevant), but defaults are permissive for normal use and behavior matches the existing `maxelements` knob.
> 
> **Overview**
> Adds **`redisReader->maxdepth`** (default **1024** via `REDIS_READER_MAX_REPLY_DEPTH`) so the reply parser rejects deeply nested aggregate replies with a protocol error (**"Max nesting depth exceeded"**) instead of recursing without bound on malicious or corrupted payloads.
> 
> The limit is enforced in **`processAggregateItem`** when entering nested arrays/maps/sets (same pattern as **`maxelements`**). Callers can raise the cap or set **`maxdepth = 0`** for unlimited nesting. README documents **`context->reader->maxdepth`**, and **`test.c`** covers default, at-limit, over-limit, and disabled behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab1790cabe9122f26914be39b1856fce082bd2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->