### PR TITLE
fix: Prevent arbitrarily nested replies from causing a stack overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,11 @@ unlimited with:
 context->reader->maxelements = 0;
 ```
 
+### Reader max nesting depth
+
+The hiredis reply parser limits nested aggregate replies to a depth of 1024.
+Replies with deeper nesting are rejected with a protocol error.
+
 ## SSL/TLS Support
 
 ### Building

--- a/read.c
+++ b/read.c
@@ -50,6 +50,9 @@
 /* Initial size of our nested reply stack and how much we grow it when needd */
 #define REDIS_READER_STACK_SIZE 9
 
+/* Maximum depth of nested aggregate replies. */
+#define REDIS_READER_MAX_REPLY_DEPTH 1024
+
 static void __redisReaderSetError(redisReader *r, int type, const char *str) {
     size_t len;
 
@@ -499,6 +502,12 @@ static int processAggregateItem(redisReader *r) {
     char *p;
     long long elements;
     int root = 0, len;
+
+    if (r->ridx >= REDIS_READER_MAX_REPLY_DEPTH) {
+        __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                "Max nesting depth exceeded");
+        return REDIS_ERR;
+    }
 
     if (r->ridx == r->tasks - 1) {
         if (redisReaderGrow(r) == REDIS_ERR)

--- a/test.c
+++ b/test.c
@@ -476,7 +476,7 @@ static void test_reply_reader(void) {
     redisReaderFree(reader);
 
     reader = redisReaderCreate();
-    test("Can handle arbitrarily nested multi-bulks: ");
+    test("Can handle deeply nested multi-bulks: ");
     for (i = 0; i < 128; i++) {
         redisReaderFeed(reader,(char*)"*1\r\n", 4);
     }
@@ -487,7 +487,7 @@ static void test_reply_reader(void) {
         ((redisReply*)reply)->type == REDIS_REPLY_ARRAY &&
         ((redisReply*)reply)->elements == 1);
 
-    test("Can parse arbitrarily nested multi-bulks correctly: ");
+    test("Can parse deeply nested multi-bulks correctly: ");
     while(i--) {
         assert(reply != NULL && ((redisReply*)reply)->type == REDIS_REPLY_ARRAY);
         reply = ((redisReply*)reply)->element[0];
@@ -495,6 +495,29 @@ static void test_reply_reader(void) {
     test_cond(((redisReply*)reply)->type == REDIS_REPLY_STRING &&
         !memcmp(((redisReply*)reply)->str, "LOLWUT", 6));
     freeReplyObject(root);
+    redisReaderFree(reader);
+
+    test("Can parse a reply at the maximum nesting depth: ");
+    reader = redisReaderCreate();
+    reader->fn = NULL;
+    for (i = 0; i < 1024; i++) {
+        redisReaderFeed(reader,(char*)"*1\r\n",4);
+    }
+    redisReaderFeed(reader,(char*)"+OK\r\n",5);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_OK && reply == (void*)REDIS_REPLY_ARRAY);
+    redisReaderFree(reader);
+
+    test("Set error when nesting depth exceeds the maximum: ");
+    reader = redisReaderCreate();
+    for (i = 0; i <= 1024; i++) {
+        redisReaderFeed(reader,(char*)"*1\r\n",4);
+    }
+    redisReaderFeed(reader,(char*)"+OK\r\n",5);
+    ret = redisReaderGetReply(reader,&reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr,"Max nesting depth exceeded") == 0);
+    freeReplyObject(reply);
     redisReaderFree(reader);
 
     test("Correctly parses LLONG_MAX: ");


### PR DESCRIPTION
Backport of the RESP parser nesting-depth limit to the 1.3.x maintenance line.

Malicious or corrupted RESP protocol data with arbitrarily deep nested aggregate replies could overflow the stack when the reply tree is recursively freed. This caps reply nesting at 1024 levels and rejects deeper replies with a protocol error, with no ABI change (no SONAME bump required).

Originally authored by @michael-grunder. Vulnerability discovered by He Huang, Swinburne University of Technology, Melbourne, Australia; discovery using NexusSan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Security hardening in the reply parser with a generous fixed limit; behavior change only for pathological nesting beyond 1024, with no ABI change.
> 
> **Overview**
> **Caps nested aggregate RESP replies at 1024 levels** so malicious or corrupt protocol data cannot drive unbounded parser recursion (stack overflow when freeing deep reply trees).
> 
> `processAggregateItem` in `read.c` now rejects deeper nesting with a **protocol error** (`Max nesting depth exceeded`). README documents the limit; tests cover depth 1024 success and depth 1025 failure (existing deep-nest cases are renamed to reflect the cap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7281719d8a077623c4d1f29ac7cf7cd4b9af1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->