### PR TITLE
Protect against overflow of map elements

### DIFF
--- a/read.c
+++ b/read.c
@@ -601,7 +601,21 @@ static int processAggregateItem(redisReader *r) {
 
             moveToNextTask(r);
         } else {
-            if (cur->type == REDIS_REPLY_MAP || cur->type == REDIS_REPLY_ATTR) elements *= 2;
+            if (cur->type == REDIS_REPLY_MAP || cur->type == REDIS_REPLY_ATTR) {
+                long long maxelements = LLONG_MAX / 2;
+                if (LLONG_MAX > SIZE_MAX &&
+                    maxelements > (long long)(SIZE_MAX / 2)) {
+                    maxelements = (long long)(SIZE_MAX / 2);
+                }
+
+                if (elements > maxelements) {
+                    __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                            "Multi-bulk length out of range");
+                    return REDIS_ERR;
+                }
+
+                elements *= 2;
+            }
 
             if (r->fn && r->fn->createArray)
                 obj = r->fn->createArray(cur,elements);

--- a/test.c
+++ b/test.c
@@ -859,6 +859,15 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
+    test("A RESP3 MAP/ATTR can't overflow: ");
+    reader = redisReaderCreate();
+    reader->maxelements = 0; /* Don't rely on default limit */
+    redisReaderFeed(reader, "%4611686018427387904\r\n", 22);
+    ret = redisReaderGetReply(reader, &reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
+    redisReaderFree(reader);
+
     test("Can parse RESP3 attribute: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, "|2\r\n+foo\r\n:123\r\n+bar\r\n#t\r\n",26);


### PR DESCRIPTION
Backport of #1323 to the 1.4.x maintenance line.

For RESP3 MAP/ATTR containers the element count is doubled since each element is a key-value pair. Before this change the doubling could overflow if a user explicitly disabled the default `reader->maxelements` limit and then parsed a MAP or ATTR reply with more than `LLONG_MAX / 2` elements. The length is now bounds-checked before doubling and rejected with a protocol error (`Multi-bulk length out of range`).

Originally authored by @michael-grunder (upstream issue #1322).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level RESP3 parsing and allocation sizing; the change is a narrow defensive check with a targeted test, but malformed input could previously have caused undefined behavior.
> 
> **Overview**
> Fixes an integer overflow when parsing **RESP3 MAP and ATTR** replies in `processAggregateItem`.
> 
> Those types store key–value pairs, so the parser doubles the declared pair count into a flat element count. Without a pre-check, a huge declared length could wrap on multiply when `reader->maxelements` is disabled (`0`), leading to incorrect allocation/parsing.
> 
> The change caps the allowed pair count at `LLONG_MAX / 2` (further limited by `SIZE_MAX / 2` where relevant) and rejects oversize lengths with **`Multi-bulk length out of range`**. A unit test feeds an oversized MAP length with `maxelements = 0` to assert that error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6d3a70c3777a6d460bab11d82f0d8357f3e63bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->