### PR TITLE
Protect against overflow of map elements

### DIFF
--- a/read.c
+++ b/read.c
@@ -544,7 +544,21 @@ static int processAggregateItem(redisReader *r) {
 
             moveToNextTask(r);
         } else {
-            if (cur->type == REDIS_REPLY_MAP || cur->type == REDIS_REPLY_ATTR) elements *= 2;
+            if (cur->type == REDIS_REPLY_MAP || cur->type == REDIS_REPLY_ATTR) {
+                long long maxelements = LLONG_MAX / 2;
+                if (LLONG_MAX > SIZE_MAX &&
+                    maxelements > (long long)(SIZE_MAX / 2)) {
+                    maxelements = (long long)(SIZE_MAX / 2);
+                }
+
+                if (elements > maxelements) {
+                    __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                            "Multi-bulk length out of range");
+                    return REDIS_ERR;
+                }
+
+                elements *= 2;
+            }
 
             if (r->fn && r->fn->createArray)
                 obj = r->fn->createArray(cur,elements);

--- a/test.c
+++ b/test.c
@@ -818,6 +818,15 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
+    test("A RESP3 MAP/ATTR can't overflow: ");
+    reader = redisReaderCreate();
+    reader->maxelements = 0; /* Don't rely on default limit */
+    redisReaderFeed(reader, "%4611686018427387904\r\n", 22);
+    ret = redisReaderGetReply(reader, &reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
+    redisReaderFree(reader);
+
     test("Can parse RESP3 attribute: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, "|2\r\n+foo\r\n:123\r\n+bar\r\n#t\r\n",26);


### PR DESCRIPTION
Backport of #1323 to the 1.3.x maintenance line.

For RESP3 MAP/ATTR containers the element count is doubled since each element is a key-value pair. Before this change the doubling could overflow if a user explicitly disabled the default `reader->maxelements` limit and then parsed a MAP or ATTR reply with more than `LLONG_MAX / 2` elements. The length is now bounds-checked before doubling and rejected with a protocol error (`Multi-bulk length out of range`).

Originally authored by @michael-grunder (upstream issue #1322).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized protocol-parser hardening with a regression test; no API or behavior change for valid replies.
> 
> **Overview**
> **RESP3 MAP and ATTR** replies double the declared pair count before allocating child slots. The reader now rejects counts that would overflow that multiply (using limits tied to `LLONG_MAX/2` and `SIZE_MAX/2`) with **`Multi-bulk length out of range`**, instead of wrapping when `reader->maxelements` is disabled.
> 
> A unit test feeds an oversized MAP length with **`maxelements = 0`** to assert the new check, not only the default element cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5461dd0f3df44b6c10e8711b0cbfdb16107698d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->