### PR TITLE
Protect against overflow of map elements

### DIFF
--- a/read.c
+++ b/read.c
@@ -543,7 +543,21 @@ static int processAggregateItem(redisReader *r) {
 
             moveToNextTask(r);
         } else {
-            if (cur->type == REDIS_REPLY_MAP) elements *= 2;
+            if (cur->type == REDIS_REPLY_MAP) {
+                long long maxelements = LLONG_MAX / 2;
+                if (LLONG_MAX > SIZE_MAX &&
+                    maxelements > (long long)(SIZE_MAX / 2)) {
+                    maxelements = (long long)(SIZE_MAX / 2);
+                }
+
+                if (elements > maxelements) {
+                    __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                            "Multi-bulk length out of range");
+                    return REDIS_ERR;
+                }
+
+                elements *= 2;
+            }
 
             if (r->fn && r->fn->createArray)
                 obj = r->fn->createArray(cur,elements);

--- a/test.c
+++ b/test.c
@@ -793,6 +793,16 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
+    test("A RESP3 MAP can't overflow: ");
+    reader = redisReaderCreate();
+    reader->maxelements = 0; /* Don't rely on default limit */
+    redisReaderFeed(reader, "%4611686018427387904\r\n", 22);
+    ret = redisReaderGetReply(reader, &reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
+    redisReaderFree(reader);
+
+
     test("Can parse RESP3 set: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, "~5\r\n+orange\r\n$5\r\napple\r\n#f\r\n:100\r\n:999\r\n",40);


### PR DESCRIPTION
Backport of #1323 to the 1.2.x maintenance line.

For RESP3 MAP containers the element count is doubled since each element is a key-value pair. Before this change the doubling could overflow if a user explicitly disabled the default `reader->maxelements` limit and then parsed a MAP reply with more than `LLONG_MAX / 2` elements. The length is now bounds-checked before doubling and rejected with a protocol error (`Multi-bulk length out of range`).

Conflict resolution vs upstream: this line does not double ATTR element counts, so the guard applies to MAP only and the regression test was renamed accordingly.

Originally authored by @michael-grunder (upstream issue #1322).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to protocol parsing with a targeted test; no API or auth changes.
> 
> **Overview**
> **Fixes integer overflow when parsing RESP3 MAP replies** by validating the declared pair count before multiplying by two (each map entry becomes two child slots). Oversized lengths now fail with `Multi-bulk length out of range` instead of wrapping, including when `reader->maxelements` is disabled.
> 
> A regression test feeds a MAP header with `LLONG_MAX/2 + 1` pairs (`%4611686018427387904`) and asserts the parser rejects it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adeee7fe889264a6c3dd1841b694d3e794b3bbe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->