### PR TITLE
Protect against overflow of map elements

### DIFF
--- a/read.c
+++ b/read.c
@@ -542,7 +542,21 @@ static int processAggregateItem(redisReader *r) {
 
             moveToNextTask(r);
         } else {
-            if (cur->type == REDIS_REPLY_MAP) elements *= 2;
+            if (cur->type == REDIS_REPLY_MAP) {
+                long long maxelements = LLONG_MAX / 2;
+                if (LLONG_MAX > SIZE_MAX &&
+                    maxelements > (long long)(SIZE_MAX / 2)) {
+                    maxelements = (long long)(SIZE_MAX / 2);
+                }
+
+                if (elements > maxelements) {
+                    __redisReaderSetError(r,REDIS_ERR_PROTOCOL,
+                            "Multi-bulk length out of range");
+                    return REDIS_ERR;
+                }
+
+                elements *= 2;
+            }
 
             if (r->fn && r->fn->createArray)
                 obj = r->fn->createArray(cur,elements);

--- a/test.c
+++ b/test.c
@@ -774,6 +774,15 @@ static void test_reply_reader(void) {
     freeReplyObject(reply);
     redisReaderFree(reader);
 
+    test("A RESP3 MAP can't overflow: ");
+    reader = redisReaderCreate();
+    reader->maxelements = 0; /* Don't rely on default limit */
+    redisReaderFeed(reader, "%4611686018427387904\r\n", 22);
+    ret = redisReaderGetReply(reader, &reply);
+    test_cond(ret == REDIS_ERR &&
+              strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
+    redisReaderFree(reader);
+
     test("Can parse RESP3 set: ");
     reader = redisReaderCreate();
     redisReaderFeed(reader, "~5\r\n+orange\r\n$5\r\napple\r\n#f\r\n:100\r\n:999\r\n",40);


### PR DESCRIPTION
Backport of #1323 to the 1.1.x maintenance line.

For RESP3 MAP containers the element count is doubled since each element is a key-value pair. Before this change the doubling could overflow if a user explicitly disabled the default `reader->maxelements` limit and then parsed a MAP reply with more than `LLONG_MAX / 2` elements. The length is now bounds-checked before doubling and rejected with a protocol error (`Multi-bulk length out of range`).

Conflict resolution vs upstream: this line does not double ATTR element counts, so the guard applies to MAP only and the regression test was renamed accordingly.

Originally authored by @michael-grunder (upstream issue #1322).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized protocol-parser hardening with a regression test; behavior for valid MAP sizes is unchanged.
> 
> **Overview**
> Fixes an integer overflow when parsing **RESP3 MAP** replies in `processAggregateItem`. MAP lengths are doubled to account for key–value pairs; without a bound, a declared pair count above `LLONG_MAX / 2` (or the `SIZE_MAX`-derived cap) could wrap after `elements *= 2`, especially when `reader->maxelements` is set to **0** to disable the default limit.
> 
> The reader now computes a safe maximum, rejects oversized MAP lengths with **`Multi-bulk length out of range`**, and only then doubles. A unit test feeds `%4611686018427387904` with `maxelements = 0` and asserts that protocol error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d29ed92afe5b43e48591106aa08adf783abaf54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->