### PR TITLE
Add ABI compatibility check workflow

### DIFF
--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -2,6 +2,9 @@ name: ABI check
 
 on:
   pull_request:
+    # Default types plus labeled/unlabeled so toggling the
+    # ignore-abi-check escape-hatch label re-evaluates the job condition
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - master
       - 'release/**'

--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -1,0 +1,81 @@
+name: ABI check
+
+on:
+  pull_request:
+    branches:
+      - master
+      - 'release/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  abi-check:
+    name: ABI compatibility (libabigail)
+    runs-on: ubuntu-latest
+    # Escape hatch for intentional, SONAME-bumped ABI breaks
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ignore-abi-check') }}
+    steps:
+      - name: Checkout head (PR merge ref)
+        uses: actions/checkout@v4
+        with:
+          path: head
+
+      - name: Checkout base (${{ github.base_ref }})
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev
+
+      - name: Get compiler version (for cache key)
+        id: cc
+        run: echo "version=$(cc -dumpfullversion -dumpversion)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache baseline libraries
+        id: cache-base
+        uses: actions/cache@v4
+        with:
+          path: base-libs
+          key: abi-base-libs-${{ runner.os }}-cc${{ steps.cc.outputs.version }}-${{ github.event.pull_request.base.sha }}
+
+      - name: Build base libraries
+        if: steps.cache-base.outputs.cache-hit != 'true'
+        run: |
+          make -C base dynamic USE_SSL=1
+          mkdir -p base-libs
+          cp base/libhiredis.so base/libhiredis_ssl.so base-libs/
+
+      - name: Build head libraries
+        run: make -C head dynamic USE_SSL=1
+
+      - name: ABI check libhiredis
+        uses: fujitatomoya/libabigail-action@v0
+        with:
+          base-lib: base-libs/libhiredis.so
+          head-lib: head/libhiredis.so
+          headers-dir-base: base
+          headers-dir-head: head
+          fail-on: incompatible
+          comment-pr: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          label-break: abi-break
+          report-name: abidiff-report-hiredis
+          marker-suffix: abi-check-hiredis
+
+      - name: ABI check libhiredis_ssl
+        if: ${{ !cancelled() }}
+        uses: fujitatomoya/libabigail-action@v0
+        with:
+          base-lib: base-libs/libhiredis_ssl.so
+          head-lib: head/libhiredis_ssl.so
+          headers-dir-base: base
+          headers-dir-head: head
+          fail-on: incompatible
+          comment-pr: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          label-break: abi-break
+          report-name: abidiff-report-hiredis-ssl
+          marker-suffix: abi-check-hiredis-ssl

--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -57,6 +57,7 @@ jobs:
         run: make -C head dynamic USE_SSL=1
 
       - name: ABI check libhiredis
+        id: abi-core
         uses: fujitatomoya/libabigail-action@v0
         with:
           base-lib: base-libs/libhiredis.so
@@ -64,12 +65,12 @@ jobs:
           headers-dir-base: base
           headers-dir-head: head
           fail-on: incompatible
-          comment-pr: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          comment-pr: false
           label-break: abi-break
           report-name: abidiff-report-hiredis
-          marker-suffix: abi-check-hiredis
 
       - name: ABI check libhiredis_ssl
+        id: abi-ssl
         if: ${{ !cancelled() }}
         uses: fujitatomoya/libabigail-action@v0
         with:
@@ -78,7 +79,62 @@ jobs:
           headers-dir-base: base
           headers-dir-head: head
           fail-on: incompatible
-          comment-pr: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          comment-pr: false
           label-break: abi-break
           report-name: abidiff-report-hiredis-ssl
-          marker-suffix: abi-check-hiredis-ssl
+
+      - name: Compose combined ABI report
+        if: ${{ !cancelled() }}
+        env:
+          CORE_VERDICT: ${{ steps.abi-core.outputs.verdict }}
+          CORE_SUMMARY: ${{ steps.abi-core.outputs.summary }}
+          CORE_REPORT: ${{ steps.abi-core.outputs.report }}
+          SSL_VERDICT: ${{ steps.abi-ssl.outputs.verdict }}
+          SSL_SUMMARY: ${{ steps.abi-ssl.outputs.summary }}
+          SSL_REPORT: ${{ steps.abi-ssl.outputs.report }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # GitHub comments are capped at 65536 chars; leave room for two reports
+          REPORT_LIMIT=25000
+          emoji() {
+            case "$1" in
+              compatible|additions-only) echo "✅" ;;
+              incompatible) echo "❌" ;;
+              *) echo "⚠️" ;;
+            esac
+          }
+          section() { # <lib name> <verdict> <summary> <report path> <artifact name>
+            echo "### $(emoji "$2") \`$1\` — ${2:-error}"
+            echo ""
+            echo "${3:-No summary produced (check the job log).}"
+            echo ""
+            if [ -n "$4" ] && [ -f "$4" ] && [ -s "$4" ]; then
+              echo "<details><summary>Full abidiff report</summary>"
+              echo ""
+              echo '```'
+              head -c "$REPORT_LIMIT" "$4"
+              if [ "$(wc -c < "$4")" -gt "$REPORT_LIMIT" ]; then
+                echo ""
+                echo "... (truncated — full report in the \`$5\` artifact)"
+              fi
+              echo '```'
+              echo ""
+              echo "</details>"
+              echo ""
+            fi
+          }
+          {
+            echo "## ABI compatibility check"
+            echo ""
+            section libhiredis "$CORE_VERDICT" "$CORE_SUMMARY" "$CORE_REPORT" abidiff-report-hiredis
+            section libhiredis_ssl "$SSL_VERDICT" "$SSL_SUMMARY" "$SSL_REPORT" abidiff-report-hiredis-ssl
+            echo "_Baseline \`${BASE_SHA}\` vs head \`${HEAD_SHA}\`. Apply the \`ignore-abi-check\` label to skip this check for an intentional, SONAME-bumped ABI break._"
+          } > abi-comment.md
+
+      - name: Post combined sticky comment
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: abi-check
+          path: abi-comment.md


### PR DESCRIPTION
## What

Adds a new GitHub Actions workflow (`.github/workflows/abi-check.yml`) that verifies every PR targeting `master` or a `release/*` maintenance branch for ABI backward compatibility.

## How

- Builds `libhiredis.so` and `libhiredis_ssl.so` (with DWARF debug info, which the Makefile emits by default) from both the PR **base commit** and the PR **head**, using the same toolchain in the same job.
- Compares each pair with `abidiff` via the reusable [libabigail ABI Check](https://github.com/marketplace/actions/libabigail-abi-check) action (`fujitatomoya/libabigail-action@v0`).
- `fail-on: incompatible` — symbol **additions pass** (backward compatible), removals and type/signature changes **fail**.
- On breakage the action posts a sticky PR comment with the abidiff summary, uploads the full report as an artifact, and applies an `abi-break` label.
- The baseline build is **cached** keyed on `<runner OS> + <compiler version> + <base SHA>`, so repeated pushes to a PR (and sibling PRs sharing the same base) skip the baseline rebuild. Including the compiler version in the key prevents comparing DWARF produced by mismatched toolchains after a runner image update.
- PR comments are only attempted for same-repo PRs (fork PRs get a read-only token); the pass/fail status still applies to everyone.

## Escape hatch

An `ignore-abi-check` label on the PR skips the job — for intentional ABI breaks accompanied by a SONAME bump. Note that a PR changing `HIREDIS_SONAME` itself will also be flagged by abidiff (SONAME change counts as incompatible), which is by design: it forces an explicit maintainer acknowledgment via the label.

## Verified locally

- Identical code on both sides → `abidiff` exit 0 for both libraries.
- `release/v1.1.X` → `master`: 21 added functions, 0 removed/changed (compatible additions detected correctly).
- Reverse direction (simulated removals) → flagged incompatible.

## Follow-up

Since `pull_request` workflows run from the PR merge commit, this check only takes effect on maintenance branches once the workflow file exists there — backport PRs to `release/v1.0.X`…`release/v1.4.X` will follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no runtime library behavior; main caveat is new required check gating merges until labels or fixes are applied.
> 
> **Overview**
> Adds a new GitHub Actions workflow that runs on PRs to `master` and `release/**`, comparing **base** vs **head** builds of `libhiredis.so` and `libhiredis_ssl.so` with libabigail (`abidiff`). Incompatible ABI changes fail the check; compatible symbol additions pass.
> 
> The job checks out both SHAs, builds shared libs with `make dynamic USE_SSL=1`, and caches baseline `.so` files keyed by OS, compiler version, and base SHA. Breakages get an `abi-break` label and per-lib reports from the action; a **single sticky PR comment** merges both library summaries (with truncated abidiff details). Fork PRs still get pass/fail but skip commenting when the token cannot write.
> 
> Maintainers can skip the job with the **`ignore-abi-check`** label (including intentional SONAME bumps). The workflow also listens for `labeled`/`unlabeled` so toggling that label re-runs the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b50e27d5a44bcd9eb5891c7e67f17b6e1699ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->