### PR TITLE
Publish the combined ABI report as the workflow run summary

### DIFF
--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -69,6 +69,15 @@ jobs:
           label-break: abi-break
           report-name: abidiff-report-hiredis
 
+      # The action writes its report to a fixed path in RUNNER_TEMP, so the
+      # second invocation overwrites the first one's report — snapshot each
+      # report to a unique path right after the step that produced it
+      - name: Snapshot libhiredis report
+        if: ${{ !cancelled() }}
+        env:
+          REPORT: ${{ steps.abi-core.outputs.report }}
+        run: if [ -n "$REPORT" ] && [ -f "$REPORT" ]; then cp -f "$REPORT" abidiff-hiredis.txt; fi
+
       - name: ABI check libhiredis_ssl
         id: abi-ssl
         if: ${{ !cancelled() }}
@@ -83,15 +92,21 @@ jobs:
           label-break: abi-break
           report-name: abidiff-report-hiredis-ssl
 
+      - name: Snapshot libhiredis_ssl report
+        if: ${{ !cancelled() }}
+        env:
+          REPORT: ${{ steps.abi-ssl.outputs.report }}
+        run: if [ -n "$REPORT" ] && [ -f "$REPORT" ]; then cp -f "$REPORT" abidiff-hiredis-ssl.txt; fi
+
       - name: Compose combined ABI report
         if: ${{ !cancelled() }}
         env:
           CORE_VERDICT: ${{ steps.abi-core.outputs.verdict }}
           CORE_SUMMARY: ${{ steps.abi-core.outputs.summary }}
-          CORE_REPORT: ${{ steps.abi-core.outputs.report }}
+          CORE_REPORT: abidiff-hiredis.txt
           SSL_VERDICT: ${{ steps.abi-ssl.outputs.verdict }}
           SSL_SUMMARY: ${{ steps.abi-ssl.outputs.summary }}
-          SSL_REPORT: ${{ steps.abi-ssl.outputs.report }}
+          SSL_REPORT: abidiff-hiredis-ssl.txt
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -110,6 +125,10 @@ jobs:
             echo "${3:-No summary produced (check the job log).}"
             echo ""
             if [ -n "$4" ] && [ -f "$4" ] && [ -s "$4" ]; then
+              # Show abidiff's own change counts — the action's verdict text
+              # can mislabel layout changes as additions
+              grep -E '^(Functions|Variables) changes summary|^ELF SONAME changed' "$4" | sed 's/^/- /' || true
+              echo ""
               echo "<details><summary>Full abidiff report</summary>"
               echo ""
               echo '```'

--- a/.github/workflows/abi-check.yml
+++ b/.github/workflows/abi-check.yml
@@ -131,6 +131,10 @@ jobs:
             section libhiredis_ssl "$SSL_VERDICT" "$SSL_SUMMARY" "$SSL_REPORT" abidiff-report-hiredis-ssl
             echo "_Baseline \`${BASE_SHA}\` vs head \`${HEAD_SHA}\`. Apply the \`ignore-abi-check\` label to skip this check for an intentional, SONAME-bumped ABI break._"
           } > abi-comment.md
+          # Publish the same report as the workflow run summary, so it is
+          # visible on the run overview even when the sticky comment cannot
+          # be posted (e.g. fork PRs with a read-only token)
+          cat abi-comment.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Post combined sticky comment
         if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
Follow-up to #1345 (merged before this commit was pushed).

Writes the composed abidiff report to `$GITHUB_STEP_SUMMARY`, so the per-library verdicts and collapsible full reports appear directly on the workflow run overview page.

Besides making review easier, this covers the fork-PR gap: for PRs from forks the read-only token prevents posting the sticky PR comment (as seen on the #1335 run), but the run summary is always rendered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no runtime or library behavior impact.
> 
> **Overview**
> **The ABI workflow now keeps separate abidiff reports for `libhiredis` and `libhiredis_ssl` and surfaces the combined report on the Actions run page.**
> 
> Because `libabigail-action` reuses the same report path under `RUNNER_TEMP`, snapshot steps copy each library’s report to `abidiff-hiredis.txt` and `abidiff-hiredis-ssl.txt` right after its check. The compose step reads those files instead of the action output paths so both libraries’ details stay in one `abi-comment.md`.
> 
> The composed markdown is **appended to `$GITHUB_STEP_SUMMARY`**, so reviewers see the same verdicts and collapsible full reports on the workflow run overview when a sticky PR comment cannot be posted (e.g. fork PRs).
> 
> Each library section also pulls **abidiff’s own change-count / SONAME lines** from the report file, since the action’s verdict text can mislabel layout changes as additions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c442df6b7a14dd62ed9e87ff297e7464069d2d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->