### PR TITLE
Rework searching for openssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ ifeq ($(USE_SSL),1)
 
       ifneq ($(wildcard $(SEARCH_PATH1)),)
         OPENSSL_PREFIX=$(SEARCH_PATH1)
-      else ifneq($(wildcard $(SEARCH_PATH2)),)
+      else ifneq ($(wildcard $(SEARCH_PATH2)),)
         OPENSSL_PREFIX=$(SEARCH_PATH2)
       endif
     endif

--- a/Makefile
+++ b/Makefile
@@ -92,18 +92,25 @@ ifeq ($(TEST_ASYNC),1)
 endif
 
 ifeq ($(USE_SSL),1)
-  ifeq ($(uname_S),Linux)
-    ifdef OPENSSL_PREFIX
-      CFLAGS+=-I$(OPENSSL_PREFIX)/include
-      SSL_LDFLAGS+=-L$(OPENSSL_PREFIX)/lib -lssl -lcrypto
-    else
-      SSL_LDFLAGS=-lssl -lcrypto
+  ifndef OPENSSL_PREFIX
+    ifeq ($(uname_S),Darwin)
+      SEARCH_PATH1=/opt/homebrew/opt/openssl
+      SEARCH_PATH2=/usr/local/opt/openssl
+
+      ifneq ($(wildcard $(SEARCH_PATH1)),)
+        OPENSSL_PREFIX=$(SEARCH_PATH1)
+      else ifneq($(wildcard $(SEARCH_PATH2)),)
+        OPENSSL_PREFIX=$(SEARCH_PATH2)
+      endif
     endif
-  else
-    OPENSSL_PREFIX?=/usr/local/opt/openssl
-    CFLAGS+=-I$(OPENSSL_PREFIX)/include
-    SSL_LDFLAGS+=-L$(OPENSSL_PREFIX)/lib -lssl -lcrypto
   endif
+
+  ifdef OPENSSL_PREFIX
+    CFLAGS+=-I$(OPENSSL_PREFIX)/include
+    SSL_LDFLAGS+=-L$(OPENSSL_PREFIX)/lib
+  endif
+
+  SSL_LDFLAGS+=-lssl -lcrypto
 endif
 
 ifeq ($(uname_S),FreeBSD)


### PR DESCRIPTION
Backport of 4ca8e73 + aacb84b (master) to `release/v1.1.X`.

The Makefile only looked for Homebrew OpenSSL under `/usr/local/opt/openssl` (Intel path), so `USE_SSL=1 make` fails on Apple Silicon runners (`macos-latest`) with `openssl/ssl.h: file not found`. This adds the `/opt/homebrew/opt/openssl` search path, fixing the macOS CI job.

Original author: @michael-grunder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Makefile changes with no runtime or security logic; scope is limited to SSL compile/link discovery on macOS and consistent `-lssl -lcrypto` linking.
> 
> **Overview**
> **Fixes `USE_SSL=1` builds on Apple Silicon macOS** where the Makefile only considered Intel Homebrew’s `/usr/local/opt/openssl`, causing missing `openssl/ssl.h` on CI (`macos-latest`).
> 
> When `OPENSSL_PREFIX` is unset on Darwin, the Makefile now picks the first existing path between `/opt/homebrew/opt/openssl` and `/usr/local/opt/openssl`. OpenSSL include/lib flags are applied only when a prefix is known; `-lssl` and `-lcrypto` are always appended for SSL builds, including Linux when no prefix is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c9ec5dd783af1ce98b33839460958991958afb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->