### PR TITLE
Update minimum CMake version to 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,3 +139,29 @@ jobs:
           HIREDIS_PATH: ${{ github.workspace }}
         run: |
           make clean && make
+
+  test-cmake-version:
+    name: Test build with CMake ${{ matrix.cmake-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cmake-version: [
+          '3.7.0', # Minimum version
+          '3.22.0', # Ubuntu 22.04 LTS
+          '3.28.0', # Ubuntu 24.04 LTS
+          '4.0.0' # Latest version
+        ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: ${{ matrix.cmake-version }}
+      - name: Install hiredis dependencies
+        run: |          
+          sudo apt-get install -y libssl-dev libevent-dev
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake -DENABLE_SSL=ON -DENABLE_SSL_TESTS=ON -DENABLE_ASYNC_TESTS=ON -DENABLE_EXAMPLES=ON ..
+          make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 OPTION(ENABLE_SSL "Build hiredis_ssl for SSL support" OFF)
 OPTION(DISABLE_TESTS "If tests should be compiled or not" OFF)


### PR DESCRIPTION
Backport of 1387948 (master) to `release/v1.1.X`.

CMake 4.x (now the default on `windows-latest` runners) removed compatibility with `CMAKE_MINIMUM_REQUIRED` versions below 3.5, which broke the Windows CI job on this branch. This bumps the minimum to 3.7 and adds the `test-cmake-version` matrix job (3.7 / 3.22 / 3.28 / 4.0) to keep it covered.

Original author: @uglide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI-only change with a modest CMake floor bump; no runtime or security-sensitive code paths.
> 
> **Overview**
> Raises **`CMAKE_MINIMUM_REQUIRED`** from **3.0.0** to **3.7.0** so builds stay compatible with **CMake 4.x** (which dropped support for projects declaring a minimum below 3.5), fixing broken **Windows** CI on current runners.
> 
> Adds a **`test-cmake-version`** GitHub Actions job that builds with CMake **3.7.0** (new floor), **3.22.0**, **3.28.0**, and **4.0.0**, with SSL/async tests and examples enabled, to keep that range covered going forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee6e213412652cf0d9b4a96b0f544f202b2c535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->