### PR TITLE
Handle RESP3 push notifications arriving before or after replies

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -990,17 +990,6 @@ oom:
     return REDIS_ERR;
 }
 
-/* Internal helper function to try and get a reply from the reader,
- * or set an error in the context otherwise. */
-int redisGetReplyFromReader(redisContext *c, void **reply) {
-    if (redisReaderGetReply(c->reader,reply) == REDIS_ERR) {
-        __redisSetError(c,c->reader->err,c->reader->errstr);
-        return REDIS_ERR;
-    }
-
-    return REDIS_OK;
-}
-
 /* Internal helper that returns 1 if the reply was a RESP3 PUSH
  * message and we handled it with a user-provided callback. */
 static int redisHandledPushReply(redisContext *c, void *reply) {
@@ -1010,6 +999,19 @@ static int redisHandledPushReply(redisContext *c, void *reply) {
     }
 
     return 0;
+}
+
+/* Internal helper function to try and get a reply from the reader,
+ * or set an error in the context otherwise. */
+int redisGetReplyFromReader(redisContext *c, void **reply) {
+    do {
+        if (redisReaderGetReply(c->reader,reply) == REDIS_ERR) {
+            __redisSetError(c,c->reader->err,c->reader->errstr);
+            return REDIS_ERR;
+        }
+    } while (redisHandledPushReply(c, *reply));
+
+    return REDIS_OK;
 }
 
 int redisGetReply(redisContext *c, void **reply) {
@@ -1033,12 +1035,8 @@ int redisGetReply(redisContext *c, void **reply) {
             if (redisBufferRead(c) == REDIS_ERR)
                 return REDIS_ERR;
 
-            /* We loop here in case the user has specified a RESP3
-             * PUSH handler (e.g. for client tracking). */
-            do {
-                if (redisGetReplyFromReader(c,&aux) == REDIS_ERR)
-                    return REDIS_ERR;
-            } while (redisHandledPushReply(c, aux));
+            if (redisGetReplyFromReader(c,&aux) == REDIS_ERR)
+                return REDIS_ERR;
         } while (aux == NULL);
     }
 

--- a/hiredis.c
+++ b/hiredis.c
@@ -258,7 +258,8 @@ static void *createNilObject(const redisReadTask *task) {
         parent = task->parent->obj;
         assert(parent->type == REDIS_REPLY_ARRAY ||
                parent->type == REDIS_REPLY_MAP ||
-               parent->type == REDIS_REPLY_SET);
+               parent->type == REDIS_REPLY_SET ||
+               parent->type == REDIS_REPLY_PUSH);
         parent->element[task->idx] = r;
     }
     return r;

--- a/hiredis.c
+++ b/hiredis.c
@@ -1001,14 +1001,23 @@ static int redisHandledPushReply(redisContext *c, void *reply) {
     return 0;
 }
 
-/* Internal helper function to try and get a reply from the reader,
- * or set an error in the context otherwise. */
+/* Get a reply from our reader or set an error in the context. */
 int redisGetReplyFromReader(redisContext *c, void **reply) {
+    if (redisReaderGetReply(c->reader, reply) == REDIS_ERR) {
+        __redisSetError(c,c->reader->err,c->reader->errstr);
+        return REDIS_ERR;
+    }
+
+    return REDIS_OK;
+}
+
+/* Internal helper to get the next reply from our reader while handling
+ * any PUSH messages we encounter along the way.  This is separate from
+ * redisGetReplyFromReader so as to not change its behavior. */
+static int redisNextInBandReplyFromReader(redisContext *c, void **reply) {
     do {
-        if (redisReaderGetReply(c->reader,reply) == REDIS_ERR) {
-            __redisSetError(c,c->reader->err,c->reader->errstr);
+        if (redisGetReplyFromReader(c, reply) == REDIS_ERR)
             return REDIS_ERR;
-        }
     } while (redisHandledPushReply(c, *reply));
 
     return REDIS_OK;
@@ -1019,7 +1028,7 @@ int redisGetReply(redisContext *c, void **reply) {
     void *aux = NULL;
 
     /* Try to read pending replies */
-    if (redisGetReplyFromReader(c,&aux) == REDIS_ERR)
+    if (redisNextInBandReplyFromReader(c,&aux) == REDIS_ERR)
         return REDIS_ERR;
 
     /* For the blocking context, flush output buffer and read reply */
@@ -1035,7 +1044,7 @@ int redisGetReply(redisContext *c, void **reply) {
             if (redisBufferRead(c) == REDIS_ERR)
                 return REDIS_ERR;
 
-            if (redisGetReplyFromReader(c,&aux) == REDIS_ERR)
+            if (redisNextInBandReplyFromReader(c,&aux) == REDIS_ERR)
                 return REDIS_ERR;
         } while (aux == NULL);
     }

--- a/test.c
+++ b/test.c
@@ -775,7 +775,7 @@ static void test_resp3_push_handler(redisContext *c) {
     reply = redisCommand(c, "SET key:0 val:0");
     /* We need another command because depending on the version of Redis, the
      * notification may be delivered after the command's reply. */
-    test_cond(reply != NULL);
+    assert(reply != NULL);
     freeReplyObject(reply);
     reply = redisCommand(c, "PING");
     test_cond(reply != NULL && reply->type == REDIS_REPLY_STATUS && pc.str == 1);
@@ -783,6 +783,9 @@ static void test_resp3_push_handler(redisContext *c) {
 
     test("We properly handle a NIL invalidation payload: ");
     reply = redisCommand(c, "FLUSHDB");
+    assert(reply != NULL);
+    freeReplyObject(reply);
+    reply = redisCommand(c, "PING");
     test_cond(reply != NULL && reply->type == REDIS_REPLY_STATUS && pc.nil == 1);
     freeReplyObject(reply);
 

--- a/test.c
+++ b/test.c
@@ -773,6 +773,11 @@ static void test_resp3_push_handler(redisContext *c) {
     old = redisSetPushCallback(c, push_handler);
     test("We can set a custom RESP3 PUSH handler: ");
     reply = redisCommand(c, "SET key:0 val:0");
+    /* We need another command because depending on the version of Redis, the
+     * notification may be delivered after the command's reply. */
+    test_cond(reply != NULL);
+    freeReplyObject(reply);
+    reply = redisCommand(c, "PING");
     test_cond(reply != NULL && reply->type == REDIS_REPLY_STATUS && pc.str == 1);
     freeReplyObject(reply);
 
@@ -788,6 +793,12 @@ static void test_resp3_push_handler(redisContext *c) {
     assert((reply = redisCommand(c, "GET key:0")) != NULL);
     freeReplyObject(reply);
     assert((reply = redisCommand(c, "SET key:0 invalid")) != NULL);
+    /* Depending on Redis version, we may receive either push notification or
+     * status reply. Both cases are valid. */
+    if (reply->type == REDIS_REPLY_STATUS) {
+        freeReplyObject(reply);
+        reply = redisCommand(c, "PING");
+    }
     test_cond(reply->type == REDIS_REPLY_PUSH);
     freeReplyObject(reply);
 

--- a/test.c
+++ b/test.c
@@ -53,6 +53,11 @@ struct privdata {
     int dtor_counter;
 };
 
+struct pushCounters {
+    int nil;
+    int str;
+};
+
 #ifdef HIREDIS_TEST_SSL
 redisSSLContext *_ssl_ctx = NULL;
 #endif
@@ -714,11 +719,25 @@ static void test_blocking_connection_errors(void) {
 #endif
 }
 
-/* Dummy push handler */
-void push_handler(void *privdata, void *reply) {
-    int *counter = privdata;
+/* Test push handler */
+void push_handler(void *privdata, void *r) {
+    struct pushCounters *pcounts = privdata;
+    redisReply *reply = r, *payload;
+
+    assert(reply && reply->type == REDIS_REPLY_PUSH && reply->elements == 2);
+
+    payload = reply->element[1];
+    if (payload->type == REDIS_REPLY_ARRAY) {
+        payload = payload->element[0];
+    }
+
+    if (payload->type == REDIS_REPLY_STRING) {
+        pcounts->str++;
+    } else if (payload->type == REDIS_REPLY_NIL) {
+        pcounts->nil++;
+    }
+
     freeReplyObject(reply);
-    *counter += 1;
 }
 
 /* Dummy function just to test setting a callback with redisOptions */
@@ -728,16 +747,16 @@ void push_handler_async(redisAsyncContext *ac, void *reply) {
 }
 
 static void test_resp3_push_handler(redisContext *c) {
+    struct pushCounters pc = {0};
     redisPushFn *old = NULL;
     redisReply *reply;
     void *privdata;
-    int n = 0;
 
     /* Switch to RESP3 and turn on client tracking */
     send_hello(c, 3);
     send_client_tracking(c, "ON");
     privdata = c->privdata;
-    c->privdata = &n;
+    c->privdata = &pc;
 
     reply = redisCommand(c, "GET key:0");
     assert(reply != NULL);
@@ -754,7 +773,12 @@ static void test_resp3_push_handler(redisContext *c) {
     old = redisSetPushCallback(c, push_handler);
     test("We can set a custom RESP3 PUSH handler: ");
     reply = redisCommand(c, "SET key:0 val:0");
-    test_cond(reply != NULL && reply->type == REDIS_REPLY_STATUS && n == 1);
+    test_cond(reply != NULL && reply->type == REDIS_REPLY_STATUS && pc.str == 1);
+    freeReplyObject(reply);
+
+    test("We properly handle a NIL invalidation payload: ");
+    reply = redisCommand(c, "FLUSHDB");
+    test_cond(reply != NULL && reply->type == REDIS_REPLY_STATUS && pc.nil == 1);
     freeReplyObject(reply);
 
     /* Unset the push callback and generate an invalidate message making


### PR DESCRIPTION
Backport of the RESP3 push-handling fix chain (master commits b9b9f44, 6204182, dfa33e6, b455b33, 9c338a5) to `release/v1.0.X`.

Without these fixes, `redisGetReply`'s pending-reply path returns RESP3 PUSH invalidation messages in-band when they arrive buffered together with a previous reply, which breaks client-tracking users and makes the test suite fail against any Redis >= 6.0 (`test_resp3_push_handler` asserts in `send_hello`).

Verified locally: full test suite passes against Redis 6.2 and 8.2 with a clean `-Werror` build.

Original authors: @michael-grunder, @yossigo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core reply delivery for all blocking `redisCommand`/`redisGetReply` users on RESP3 with push callbacks; behavior change is intentional but affects client-tracking semantics.
> 
> **Overview**
> Fixes **RESP3 client-tracking** behavior when PUSH invalidations are already buffered: `redisGetReply` now skips out-of-band PUSH handling on every path that fetches a command reply, not only during the blocking read loop.
> 
> A new **`redisNextInBandReplyFromReader`** loops on `redisGetReplyFromReader` and invokes the push callback until a non-PUSH reply (or no handler) is returned; **`redisGetReplyFromReader`** is unchanged for other callers. **`createNilObject`** now allows NIL children under **`REDIS_REPLY_PUSH`** parents so nested invalidation payloads parse correctly.
> 
> **`test_resp3_push_handler`** is updated for Redis version timing (extra `PING`, `FLUSHDB` NIL case, in-band PUSH ordering) and a richer test push handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49d47aa1a19b9ac8e3e07cf0c5fc493a9f1ad33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->