### PR TITLE
Gracefully shut down TLS session before closing connection

### DIFF
--- a/hiredis.c
+++ b/hiredis.c
@@ -738,6 +738,12 @@ void redisFree(redisContext *c) {
     if (c == NULL)
         return;
 
+    /* We need to gracefully terminate the TLS session before closing fd. */
+    if (c->funcs && c->funcs->free_privctx) {
+        c->funcs->free_privctx(c->privctx);
+        c->privctx = NULL;
+    }
+
     if (c->funcs && c->funcs->close) {
         c->funcs->close(c);
     }
@@ -753,9 +759,6 @@ void redisFree(redisContext *c) {
 
     if (c->privdata && c->free_privdata)
         c->free_privdata(c->privdata);
-
-    if (c->funcs && c->funcs->free_privctx)
-        c->funcs->free_privctx(c->privctx);
 
     memset(c, 0xff, sizeof(*c));
     hi_free(c);

--- a/ssl.c
+++ b/ssl.c
@@ -479,6 +479,10 @@ static void redisSSLFree(void *privctx){
 
     if (!rsc) return;
     if (rsc->ssl) {
+        /* Should not be called if a previous fatal error has occurred on a connection;
+         * i.e., if SSL_get_error(3) has returned SSL_ERROR_SYSCALL or SSL_ERROR_SSL.
+         * (https://docs.openssl.org/3.3/man3/SSL_shutdown/#description). */
+        SSL_shutdown(rsc->ssl);
         SSL_free(rsc->ssl);
         rsc->ssl = NULL;
     }


### PR DESCRIPTION
Backport of the hiredis portion of redis/redis@4a7dd653794617c06f0f7eada7376e5cd5bc54cc (redis/redis#14721) to the upstream hiredis repo.

## Changes

- `redisFree()`: free the connection's `privctx` (which for TLS tears down the session) **before** closing the file descriptor, instead of after, so the TLS shutdown can still be sent over the socket.
- `redisSSLFree()`: call `SSL_shutdown()` before `SSL_free()` so the server sees a clean `close_notify` instead of an abrupt disconnect.

The `redis-cli` portions of the original commit are not applicable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to connection teardown order for TLS only; no impact on normal request/response paths or non-TLS connections.
> 
> **Overview**
> TLS clients now tear down the session in the right order when a `redisContext` is freed, so Redis (and other peers) see a proper TLS **close_notify** instead of an abrupt socket close.
> 
> **`redisFree()`** now calls `free_privctx` (and clears `privctx`) **before** `close`, so SSL shutdown can still write over the open fd. **`redisSSLFree()`** invokes **`SSL_shutdown()`** before **`SSL_free()`** to complete the handshake side of shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f19f45ddbbf633c3f00ba8dee3efbb8dddb7a908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->