### PR TITLE
Makefile: allow passing extra flags via HIREDIS_CFLAGS/HIREDIS_LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ define REDIS_TEST_CONFIG
 endef
 export REDIS_TEST_CONFIG
 
+# Flags passed from outside so as not to override CFLAGS or LDFLAGS as they may
+# be changed inside this Makefile
+HIREDIS_CFLAGS=
+HIREDIS_LDFLAGS=
+
 # Fallback to gcc when $CC is not in $PATH.
 CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 CXX:=$(shell sh -c 'type $${CXX%% *} >/dev/null 2>/dev/null && echo $(CXX) || echo g++')
@@ -45,8 +50,8 @@ ifeq ($(USE_WERROR),1)
   WARNINGS+=-Werror
 endif
 DEBUG_FLAGS?= -g -ggdb
-REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(PLATFORM_FLAGS)
-REAL_LDFLAGS=$(LDFLAGS)
+REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CPPFLAGS) $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS) $(PLATFORM_FLAGS) $(HIREDIS_CFLAGS)
+REAL_LDFLAGS=$(LDFLAGS) $(HIREDIS_LDFLAGS)
 
 DYLIBSUFFIX=so
 STLIBSUFFIX=a


### PR DESCRIPTION
Redis has carried this small Makefile patch in its vendored `deps/hiredis` copy since redis/redis#14038; upstreaming it removes one source of divergence between the repos.

When hiredis is built as a vendored dependency, the parent build often needs to inject extra compiler/linker flags. Passing them via `CFLAGS`/`LDFLAGS` on the command line overrides the flags this Makefile itself sets, so this adds dedicated pass-through variables:

- `HIREDIS_CFLAGS` — appended to `REAL_CFLAGS`
- `HIREDIS_LDFLAGS` — appended to `REAL_LDFLAGS`

Both default to empty, so a plain `make` is completely unaffected.

Verified locally:
- `make libhiredis.a` — builds as before
- `make libhiredis.a HIREDIS_CFLAGS="-DTEST_FLAG_INJECTION"` — flag reaches every compile line

Original change by @minchopaskal in redis/redis#14038.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only build wiring with empty defaults; no runtime or library behavior changes.
> 
> **Overview**
> Adds **`HIREDIS_CFLAGS`** and **`HIREDIS_LDFLAGS`** so parent builds (e.g. vendored hiredis in Redis) can inject extra compile/link flags without replacing the Makefile’s own **`CFLAGS`** / **`LDFLAGS`**, which would drop hiredis’s internal flag setup.
> 
> Both variables default to empty and are **appended** to **`REAL_CFLAGS`** and **`REAL_LDFLAGS`**, so a normal **`make`** behavior is unchanged while **`make … HIREDIS_CFLAGS="…"`** still reaches all compile/link lines that use those variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b9b08c0a125b095c54227ba73d8b17483c58dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->