### PR TITLE
Fix flaky SSL reconnect test and '(null)' handshake error message

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -477,8 +477,11 @@ static int redisSSLConnect(redisContext *c, SSL *ssl) {
             snprintf(err,sizeof(err)-1,"SSL_connect failed: %s",strerror(errno));
         else {
             unsigned long e = ERR_peek_last_error();
+            const char *reason = ERR_reason_error_string(e);
+            /* The error queue may be empty, e.g. when the handshake fails on
+             * a socket read that timed out; don't print "(null)". */
             snprintf(err,sizeof(err)-1,"SSL_connect failed: %s",
-                    ERR_reason_error_string(e));
+                    reason ? reason : "unknown error");
         }
         __redisSetError(c, REDIS_ERR_IO, err);
     }

--- a/test.c
+++ b/test.c
@@ -1408,6 +1408,14 @@ static void test_blocking_connection_timeouts(struct config config) {
         test_skipped();
     }
 
+    /* The 10ms timeout is only needed by the timeout tests above; if it stays
+     * on the context, redisReconnect() re-applies it to the new socket and the
+     * TLS handshake in do_reconnect() must then finish every read within it,
+     * which is flaky on slow machines. */
+    tv.tv_sec = 1;
+    tv.tv_usec = 0;
+    redisSetTimeout(c, tv);
+
     test("Reconnect properly reconnects after a timeout: ");
     do_reconnect(c, config);
     reply = redisCommand(c, "PING");


### PR DESCRIPTION
## Problem

The macOS CI job on #1355 failed in test #171 `Reconnect properly uses owned parameters` with:

```
SSL error: SSL_connect failed: (null)
```

([failing run](https://github.com/redis/hiredis/actions/runs/31819977030/job/95354246431))

The failure is a latent flake on master, unrelated to that PR:

1. `test_blocking_connection_timeouts()` sets a **10 ms recv timeout** on the context for the command-timeout test and leaves it there.
2. `redisReconnect()` re-applies the stored command timeout to the new socket (correct library behavior).
3. In SSL mode, `do_reconnect()` then re-runs the TLS handshake, so every handshake read must complete within 10 ms.
4. On a loaded runner a read times out (EAGAIN). OpenSSL's socket BIO reports it as retryable, so `SSL_get_error()` returns `SSL_ERROR_WANT_READ`; on a blocking context `redisSSLConnect()` treats that as a failure and formats `ERR_reason_error_string(ERR_peek_last_error())` — but the error queue is empty, so the string is NULL and the message is the unhelpful `SSL_connect failed: (null)`.

The mechanism is confirmed by a deterministic reproduction: a TLS handshake against a TCP listener that accepts but never responds, with a 10 ms recv timeout on the context, fails with exactly `SSL_connect failed: (null)` before this change and `SSL_connect failed: unknown error` after.

## Fix

- **test.c**: restore a generous (1 s) timeout after the command-timeout test, before the reconnect tests. The 10 ms timeout is only needed for the timeout assertion; the reconnect tests verify recovery from an errored context and that reconnect uses context-owned parameters — neither depends on the timeout value.
- **ssl.c**: guard the NULL return of `ERR_reason_error_string()` so a handshake failure with an empty error queue produces a readable message instead of `(null)`.

The flake cannot be reproduced by shrinking the timeout on an idle machine (loopback reads rarely block), which is why it only surfaces on slow CI runners.

## Testing

`TEST_SSL=1 ./test.sh` against a TLS-enabled server: all 218 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8c81265dddc88d99187bbcb00e7fb931ddc21f30. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
